### PR TITLE
feature: Adding multiple zones in traffic notifications

### DIFF
--- a/calcs/cpa_tcpa.js
+++ b/calcs/cpa_tcpa.js
@@ -21,7 +21,6 @@ var motionpredict = require('lethexa-motionpredict').withMathFunc(MathFunc)
 const _ = require('lodash')
 var alarmSent = []
 var notificationLevels = [
-  'nominal',
   'normal',
   'alert',
   'warn',

--- a/calcs/cpa_tcpa.js
+++ b/calcs/cpa_tcpa.js
@@ -55,7 +55,7 @@ module.exports = function (app, plugin) {
       },
       sendNotifications: {
         type: 'boolean',
-        title: 'Send dangerous targets notifications',
+        title: 'Global send dangerous targets notifications. You must also enable "Calculates closest point of approach distance and time..."',
         default: true
       },
       ['notificationZones']: {
@@ -86,7 +86,7 @@ module.exports = function (app, plugin) {
             },
             active: {
               type: 'boolean',
-              title: 'Send notification for this zone',
+              title: 'Send notification for this zone. You must also enable "Global send dangerous targets notifications..."',
               default: true
             }
           }

--- a/calcs/cpa_tcpa.js
+++ b/calcs/cpa_tcpa.js
@@ -20,6 +20,14 @@ const geolib = require('geolib')
 var motionpredict = require('lethexa-motionpredict').withMathFunc(MathFunc)
 const _ = require('lodash')
 var alarmSent = []
+var notificationLevels = [
+  'nominal',
+  'normal',
+  'alert',
+  'warn',
+  'alarm',
+  'emergency'
+]
 
 module.exports = function (app, plugin) {
   return {
@@ -50,15 +58,39 @@ module.exports = function (app, plugin) {
         title: 'Send dangerous targets notifications',
         default: true
       },
-      notificationRange: {
-        type: 'number',
-        title: 'Dangerous targets notification CPA limit (m)',
-        default: 1852
-      },
-      notificationTimeLimit: {
-        type: 'number',
-        title: 'Dangerous targets notification TCPA limit (s)',
-        default: 600
+      ['notificationZones']: {
+        type: 'array',
+        title:
+          'Dangerous targets notification zone (CPA limit / TCPA limit => Notification level)',
+        items: {
+          type: 'object',
+          required: ['range', 'timeLimit', 'level'],
+          properties: {
+            range: {
+              type: 'number',
+              title: 'Dangerous targets notification CPA limit (m)',
+              description: ' ',
+              default: 1852
+            },
+            timeLimit: {
+              type: 'number',
+              title: 'Dangerous targets notification TCPA limit (s)',
+              description: ' ',
+              default: 600
+            },
+            level: {
+              type: 'string',
+              title: 'Notification level of notification for this zone',
+              enum: notificationLevels,
+              default: 'alert'
+            },
+            active: {
+              type: 'boolean',
+              title: 'Send notification for this zone',
+              default: true
+            }
+          }
+        }
       }
     },
     debounceDelay: 5 * 1000,
@@ -201,12 +233,26 @@ module.exports = function (app, plugin) {
               plugin.properties.traffic.sendNotifications
             ) {
               let alarmDelta
-              if (
-                cpa != null &&
-                tcpa != null &&
-                cpa <= plugin.properties.traffic.notificationRange &&
-                tcpa <= plugin.properties.traffic.notificationTimeLimit
-              ) {
+              let notificationLevelIndex = 0
+              if (cpa != null && tcpa != null) {
+                plugin.properties.traffic.notificationZones
+                  .filter(notificationZone => notificationZone.active === true)
+                  .forEach(notificationZone => {
+                    if (
+                      cpa <= notificationZone.range &&
+                      tcpa <= notificationZone.timeLimit
+                    ) {
+                      var newNotificationLevelIndex = notificationLevels.indexOf(
+                        notificationZone.level
+                      )
+                      notificationLevelIndex =
+                        newNotificationLevelIndex > notificationLevelIndex
+                          ? newNotificationLevelIndex
+                          : notificationLevelIndex
+                    }
+                  })
+              }
+              if (notificationLevelIndex > 0) {
                 var mmsi = app.getPath('vessels.' + vessel + '.mmsi')
                 app.debug('sending CPA alarm for ' + mmsi)
                 let vesselName = app.getPath('vessels.' + vessel + '.name')
@@ -222,7 +268,7 @@ module.exports = function (app, plugin) {
                           path:
                             'notifications.navigation.closestApproach.' + mmsi,
                           value: {
-                            state: 'alert',
+                            state: notificationLevels[notificationLevelIndex],
                             method: ['visual', 'sound'],
                             message: `Crossing vessel ${vesselName} ${cpa} m away in ${(
                               tcpa / 60
@@ -275,22 +321,18 @@ function CPA_TCPA (cpa, tcpa) {
     value:
       cpa != null
         ? {
-          distance: cpa,
-          timeTo: tcpa
-        }
+            distance: cpa,
+            timeTo: tcpa
+          }
         : null,
     timestamp: new Date().toISOString()
   }
 }
 
 function generateSpeedVector (position, speed, course) {
-  var northSpeed = speed * Math.cos(course) / 1.94384 / 60 / 3600 // to degrees per second (knots/60 angle minutes /3600 s/h)
+  var northSpeed = (speed * Math.cos(course)) / 1.94384 / 60 / 3600 // to degrees per second (knots/60 angle minutes /3600 s/h)
   var eastSpeed =
-    speed *
-    Math.sin(course) /
-    1.94384 /
-    60 /
-    3600 *
+    ((speed * Math.sin(course)) / 1.94384 / 60 / 3600) *
     Math.abs(Math.sin(position.latitude)) // to degrees per second
   return [northSpeed, eastSpeed, 0]
 }

--- a/index.js
+++ b/index.js
@@ -41,7 +41,10 @@ module.exports = function (app) {
     if (!plugin.properties.tank_instances) {
       plugin.properties.tank_instances = defaultTanks
     }
-
+    if (!plugin.properties.traffic.notificationZones) {
+      plugin.properties.traffic.notificationZones = []
+    }
+    updateOldTrafficConfig()
     plugin.engines = plugin.properties.engine_instances
       .split(',')
       .map(e => e.trim())
@@ -51,7 +54,6 @@ module.exports = function (app) {
     plugin.tanks = plugin.properties.tank_instances
       .split(',')
       .map(e => e.trim())
-
     calculations = load_calcs(app, plugin, 'calcs')
     calculations = [].concat.apply([], calculations)
 
@@ -309,6 +311,23 @@ module.exports = function (app) {
 
     // app.debug('schema: ' + JSON.stringify(schema, null, 2))
     // app.debug('uiSchema: ' + JSON.stringify(uiSchema, null, 2))
+  }
+
+  function updateOldTrafficConfig () {
+    if (
+      !_.isUndefined(plugin.properties.traffic.notificationRange) ||
+      !_.isUndefined(plugin.properties.traffic.notificationTimeLimit)
+    ) {
+      plugin.properties.traffic.notificationZones.push({
+        range: plugin.properties.traffic.notificationRange || 1852,
+        timeLimit: plugin.properties.traffic.notificationTimeLimit || 600,
+        level: 'alert',
+        active: plugin.properties.traffic.sendNotifications
+      })
+      delete plugin.properties.traffic.notificationRange
+      delete plugin.properties.traffic.notificationTimeLimit
+      app.savePluginOptions(plugin.properties)
+    }
   }
 
   return plugin


### PR DESCRIPTION
- Adding multiple zones in traffic notifications.
- I kept the checkbox `Send dangerous targets notifications` in global, easy to disable everything, and there is another one per zone.
- When loading, there is an update of the `traffic` configuration for users with an old configuration. The outdated values in the configuration are destroyed after the update.
- I ran `prettier-standard` only on `index.js` & `cpa_tcpa.js`.
