### PR TITLE
fix: use design.draft.value.maximum for depthBelowSurface if available

### DIFF
--- a/calcs/depthBelowSurface.js
+++ b/calcs/depthBelowSurface.js
@@ -2,6 +2,10 @@ const _ = require('lodash')
 
 module.exports = function (app) {
   var draft = app.getSelfPath('design.draft.maximum.value')
+    
+  if (!draft) {
+    draft = app.getSelfPath('design.draft.value.maximum')
+  }
 
   var derivedFrom =
     typeof draft === 'undefined' ? [] : ['environment.depth.belowKeel']


### PR DESCRIPTION
added "design.draft.value.maximum" as an alternative reading of "design.draft.maximum.value" as is already the case in depthBelowKeel.js. The "Depth Below Surface" tick-box in the SignalK-plugin-config doesn't work otherwise.