### PR TITLE
Bugfix: retrieve depth.transducerToKeel in calculation, not at start-up

### DIFF
--- a/calcs/depthBelowKeel2.js
+++ b/calcs/depthBelowKeel2.js
@@ -1,28 +1,28 @@
 const _ = require('lodash')
 
 module.exports = function (app) {
-  var depthTransducerToKeel = app.getSelfPath(
-    'environment.depth.transducerToKeel.value'
-  )
-
-  var derivedFrom =
-    typeof depthTransducerToKeel === 'undefined'
-      ? []
-      : ['environment.depth.belowTransducer']
-
   return {
     group: 'depth',
     optionKey: 'belowKeel_2',
-    title:
-      'Depth Below Keel (based on depth.belowTransducer and depth.transducerToKeel)',
-    derivedFrom: derivedFrom,
-    calculator: function (depthBelowTransducer) {
+    title: 'Depth Below Keel (based on depth.belowTransducer and depth.transducerToKeel)',
+    derivedFrom: ['environment.depth.belowTransducer', 'environment.depth.transducerToKeel'],
+    calculator: function (depthBelowTransducer, depthTransducerToKeel) {
+      if (!depthBelowTransducer || !depthTransducerToKeel) {
+        return undefined
+      }
+
+      const value = depthBelowTransducer + depthTransducerToKeel
+
+      if (isNaN(value)) {
+        return undefined
+      }
+
       return [
         {
           path: 'environment.depth.belowKeel',
-          value: depthBelowTransducer + depthTransducerToKeel
-        }
+          value,
+        },
       ]
-    }
+    },
   }
 }

--- a/calcs/depthBelowKeel2.js
+++ b/calcs/depthBelowKeel2.js
@@ -1,22 +1,24 @@
 const _ = require('lodash')
 
 module.exports = function (app) {
-  let depthTransducerToKeel = app.getSelfPath('environment.depth.transducerToKeel.value') || 0
+  let depthTransducerToKeel =
+    app.getSelfPath('environment.depth.transducerToKeel.value') || 0
 
   return {
     group: 'depth',
     optionKey: 'belowKeel_2',
-    title: 'Depth Below Keel (based on depth.belowTransducer and depth.transducerToKeel)',
-    derivedFrom: ['environment.depth.belowTransducer', 'environment.depth.transducerToKeel'],
-    calculator: function (depthBelowTransducer, transducerToKeel) {
-      if (typeof transducerToKeel === 'number') {
-        depthTransducerToKeel = transducerToKeel
-      } else {
-        depthTransducerToKeel = app.getSelfPath('environment.depth.transducerToKeel.value') || 0
-      }
+    title:
+      'Depth Below Keel (based on depth.belowTransducer and depth.transducerToKeel)',
+    derivedFrom: ['environment.depth.belowTransducer'],
+    calculator: function (depthBelowTransducer) {
+      depthTransducerToKeel =
+        app.getSelfPath('environment.depth.transducerToKeel.value') || 0
 
       // Need to check if number, because 0 is a valid value but also falsy
-      if (typeof depthBelowTransducer !== 'number' || typeof depthTransducerToKeel !== 'number') {
+      if (
+        typeof depthBelowTransducer !== 'number' ||
+        typeof depthTransducerToKeel !== 'number'
+      ) {
         return undefined
       }
 
@@ -26,12 +28,7 @@ module.exports = function (app) {
         return undefined
       }
 
-      return [
-        {
-          path: 'environment.depth.belowKeel',
-          value,
-        },
-      ]
-    },
+      return [{ path: 'environment.depth.belowKeel', value }]
+    }
   }
 }

--- a/calcs/depthBelowKeel2.js
+++ b/calcs/depthBelowKeel2.js
@@ -1,7 +1,7 @@
 const _ = require('lodash')
 
 module.exports = function (app) {
-  let depthTransducerToKeel = app.getSelfPath('environment.depth.transducerToKeel.value')
+  let depthTransducerToKeel = app.getSelfPath('environment.depth.transducerToKeel.value') || 0
 
   return {
     group: 'depth',
@@ -11,6 +11,8 @@ module.exports = function (app) {
     calculator: function (depthBelowTransducer, transducerToKeel) {
       if (typeof transducerToKeel === 'number') {
         depthTransducerToKeel = transducerToKeel
+      } else {
+        depthTransducerToKeel = app.getSelfPath('environment.depth.transducerToKeel.value') || 0
       }
 
       // Need to check if number, because 0 is a valid value but also falsy

--- a/calcs/depthBelowKeel2.js
+++ b/calcs/depthBelowKeel2.js
@@ -1,9 +1,6 @@
 const _ = require('lodash')
 
 module.exports = function (app) {
-  let depthTransducerToKeel =
-    app.getSelfPath('environment.depth.transducerToKeel.value') || 0
-
   return {
     group: 'depth',
     optionKey: 'belowKeel_2',
@@ -11,7 +8,7 @@ module.exports = function (app) {
       'Depth Below Keel (based on depth.belowTransducer and depth.transducerToKeel)',
     derivedFrom: ['environment.depth.belowTransducer'],
     calculator: function (depthBelowTransducer) {
-      depthTransducerToKeel =
+      const depthTransducerToKeel =
         app.getSelfPath('environment.depth.transducerToKeel.value') || 0
 
       // Need to check if number, because 0 is a valid value but also falsy

--- a/calcs/depthBelowKeel2.js
+++ b/calcs/depthBelowKeel2.js
@@ -1,13 +1,20 @@
 const _ = require('lodash')
 
 module.exports = function (app) {
+  let depthTransducerToKeel = app.getSelfPath('environment.depth.transducerToKeel.value')
+
   return {
     group: 'depth',
     optionKey: 'belowKeel_2',
     title: 'Depth Below Keel (based on depth.belowTransducer and depth.transducerToKeel)',
     derivedFrom: ['environment.depth.belowTransducer', 'environment.depth.transducerToKeel'],
-    calculator: function (depthBelowTransducer, depthTransducerToKeel) {
-      if (!depthBelowTransducer || !depthTransducerToKeel) {
+    calculator: function (depthBelowTransducer, transducerToKeel) {
+      if (typeof transducerToKeel === 'number') {
+        depthTransducerToKeel = transducerToKeel
+      }
+
+      // Need to check if number, because 0 is a valid value but also falsy
+      if (typeof depthBelowTransducer !== 'number' || typeof depthTransducerToKeel !== 'number') {
         return undefined
       }
 


### PR DESCRIPTION
This bug fix intends to fix issue https://github.com/SignalK/signalk-derived-data/issues/49

The change calculates `depth.belowKeel` using the current value for `depth.transducerToKeel`, rather than that value at server start-up. There are various cases where this value is not present at that time or changes later in time:

- Lifting keel
- `depth.transducerToKeel` source is not the server config, but a "live" source
- depth transducer is not in a fixed point
- etc

