### PR TITLE
fix: Change input for calculation of secondsSinceVesselUpdate consistently to epoch time format

### DIFF
--- a/calcs/cpa_tcpa.js
+++ b/calcs/cpa_tcpa.js
@@ -152,12 +152,16 @@ module.exports = function (app, plugin) {
           var vesselTimestamp = app.getPath(
             'vessels.' + vessel + '.navigation.position.timestamp'
           )
-          var currentTime = new Date(
-            app.getSelfPath('navigation.datetime.value')
-          )
-          if (!currentTime) {
-            currentTime = new Date().toISOString()
+          vesselTimestamp = new Date(vesselTimestamp).getTime()
+
+          var currentTime
+          var currentTimeString = app.getSelfPath('navigation.datetime.value')
+          if ( currentTimeString ) {
+            currentTime = new Date(currentTimeString).getTime()
+          } else {
+            currentTime = Date.now()
           }
+
           var secondsSinceVesselUpdate = Math.floor(
             (currentTime - vesselTimestamp) / 1e3
           )


### PR DESCRIPTION
Convert both timestamps that are input for the calculation of secondsSinceVesselUpdate to epoch time. Background: Calculation of secondsSinceVesselUpdate failed with NaN since the format of the timestamps that are used for the calculation of secondsSinceVesselUpdate was inconsistent.