### PR TITLE
fix: Assign TWA and GWA identically to AWA in case AWS is smaller than 1e-9m/s

### DIFF
--- a/calcs/groundWind.js
+++ b/calcs/groundWind.js
@@ -16,6 +16,9 @@ module.exports = function (app, plugin) {
         var speed = Math.sqrt(
           Math.pow(apparentY, 2) + Math.pow(-sog + apparentX, 2)
         )
+ 
+        if (aws < 1e-9) {angle = awa} 
+
         return [
           { path: 'environment.wind.angleTrueGround', value: angle },
           { path: 'environment.wind.speedOverGround', value: speed }

--- a/calcs/trueWind.js
+++ b/calcs/trueWind.js
@@ -18,6 +18,8 @@ module.exports = function (app) {
         Math.pow(apparentY, 2) + Math.pow(-speed + apparentX, 2)
       )
 
+      if (aws < 1e-9) {angle = awa}
+
       var dir = headTrue + angle
 
       if (dir > Math.PI * 2) {


### PR DESCRIPTION
Set wind.angleTrueWater (TWA) and wind.angleTrueGround (GWA) identically to wind.angleApparent (AWA) in case wind.speedApparent (AWS) is smaller than 1e-9m/s. Background: Before for AWS=0 the plugin delivered wrong GWA and TWA since AWS=0 drove the arguments that are used for calculating the angles to zero.