### PR TITLE
ETA to next waypoint and steer error

### DIFF
--- a/calcs/eta.js
+++ b/calcs/eta.js
@@ -1,0 +1,37 @@
+module.exports = function (app) {
+  return {
+    group: 'course data',
+    optionKey: 'eta_waypoint',
+    title:
+      'Estimated time of arrival at the next waypoint using distance and VMG to course',
+    derivedFrom: ['navigation.datetime', 'navigation.courseRhumbline.nextPoint.distance', 'navigation.courseRhumbline.nextPoint.velocityMadeGood'],
+    calculator: function (datetime, distance, velocityMadeGood) {
+                var date
+
+      if (datetime && datetime.length > 0) {
+        date = new Date(datetime)
+      } else {
+        date = new Date()
+      }
+
+      var datems = date.getTime()
+      var timetopoint = Math.floor((distance / (velocityMadeGood * 0.514444)) * 1000)
+
+//      app.debug(`Using datetime: ${date} ms to point : ${timetopoint} currentms: ${datems}`)
+      var etams = datems + timetopoint
+//      app.debug(`eta in ms: ${etams} ms to point : ${timetopoint} currentms: ${datems}`)
+
+      if (velocityMadeGood > 0) {
+      var etad = new Date(parseInt(etams));
+      var eta = etad.toISOString()
+      } else {
+      var  eta = "--"
+      }
+      app.debug(`what is eta: ${eta} etams: ${etams} etad: ${etad}`)
+
+      return [
+      {
+      path: 'navigation.courseGreatCircle.nextPoint.eta', value: eta
+         }]
+  }}
+}

--- a/calcs/steer_error.js
+++ b/calcs/steer_error.js
@@ -1,0 +1,45 @@
+module.exports = function (app) {
+  return {
+    group: 'course data',
+    optionKey: 'steer_error',
+    title:
+      'Estimated steer error and direction from COGS, Bearing to next waypoint (true)',
+    derivedFrom: ['navigation.courseOverGroundTrue', 'navigation.courseRhumbline.bearingToDestinationTrue'],
+    calculator: function (courseOverGroundTrue, bearingToDestinationTrue) {
+      var steererr
+      var steer
+      var leftSteer
+      var rightSteer
+
+      steererr = courseOverGroundTrue - bearingToDestinationTrue
+      if (steererr > 3.14159265359) {
+        steer = (steererr - 3.14159265359)*-1
+      } else if (steererr < -3.14159265359) {
+        steer = (steererr + 3.14159265359)*-1
+      } else {
+        steer = steererr
+      }
+
+      if (steer > 0) {
+       leftSteer = steer,
+       rightSteer = 0
+      } else {
+       leftSteer = 0,
+       rightSteer = steer * -1
+      }
+
+     app.debug(`steer: ${steer} leftSteer: ${leftSteer} rightSteer: ${rightSteer}`)
+
+      return [
+      {
+      path: 'navigation.courseGreatCircle.nextPoint.steerError', value: steer
+         },
+      {
+      path: 'navigation.courseGreatCircle.nextPoint.leftSteerError', value: leftSteer
+         },
+      {
+      path: 'navigation.courseGreatCircle.nextPoint.rightSteerError', value: rightSteer
+         }]
+
+  }}
+}


### PR DESCRIPTION
**eta.js**

I would like to add 'eta' to next waypoint to derived data.  this file creates:
'navigation.courseGreatCircle.nextPoint.eta' and delivers a date/time of arrival at the waypoint

**steer_error.js**

this file adds a few phrases for Steer Error, this being the difference between the desired direction and the actual direction.  there are 3 different phrases:

"navigation.courseGreatCircle.nextPoint.steerError" - this gives a value for the error with a positive or negative to suggest the direction
"navigation.courseGreatCircle.nextPoint.leftSteerError" - this gives a value for the error in the Port direction
"navigation.courseGreatCircle.nextPoint.rightSteerError" - this gives a value for the error in the Starboard direction
the right and left steer error are for use to help with clear race displays to help a crew member get clear direction in the heat of a race

for examples of these being used in KIP please see:  [](https://forum.openmarine.net/showthread.php?tid=998&page=11 )

regards,
Techstyleuk (Jason Greenwood)