### PR TITLE
Magnetic variation: handle MagVar drifting over time in test

### DIFF
--- a/calcs/magneticVariation.js
+++ b/calcs/magneticVariation.js
@@ -16,8 +16,8 @@ module.exports = function (app, plugin) {
     tests: [
       {
         input: [{ latitude: 39.0631232, longitude: -76.4872768 }],
-        expected: [
-          { path: 'navigation.magneticVariation', value: -0.19355701404617112 }
+        expectedRange: [
+          { path: 'navigation.magneticVariation', value: -0.19338248112097173, delta: .05 }
         ]
       }
     ]

--- a/test/test.js
+++ b/test/test.js
@@ -46,6 +46,8 @@ describe('derived data converts', function () {
             let res = calc.calculator.apply(null, test.input)
             if (test.expected) {
               res.should.jsonEqual(test.expected)
+            } else if (test.expectedRange) {
+              res[0].value.should.closeTo(test.expectedRange[0].value, test.expectedRange[0].delta)
             } else {
               (typeof res).should.equal('undefined')
             }


### PR DESCRIPTION
test for magneticVariation calc was failing because of change in predicted value.  
Test now allows for delta around predicted value using closeTo check.