### PR TITLE
Add nextPoint.timeToGo, set estimatedTimeOfArrival as null when not available

### DIFF
--- a/calcs/eta.js
+++ b/calcs/eta.js
@@ -17,31 +17,32 @@ module.exports = function (app) {
         date = new Date()
       }
 
-      var datems = date.getTime()
-      var timetopoint = Math.floor(
-        distance / (velocityMadeGood * 0.514444) * 1000
-      )
+        var datems = date.getTime()
+        var timetopoint = Math.floor(distance / (velocityMadeGood * 0.514444) * 1000)
 
-      //      app.debug(`Using datetime: ${date} ms to point : ${timetopoint} currentms: ${datems}`)
-      var etams = datems + timetopoint
-      //      app.debug(`eta in ms: ${etams} ms to point : ${timetopoint} currentms: ${datems}`)
+        //      app.debug(`Using datetime: ${date} ms to point : ${timetopoint} currentms: ${datems}`)
+        var etams = datems + timetopoint
+        //      app.debug(`eta in ms: ${etams} ms to point : ${timetopoint} currentms: ${datems}`)
 
       if (velocityMadeGood > 0) {
         var etad = new Date(parseInt(etams))
         var eta = etad.toISOString()
+        var ttg = Math.floor((timetopoint / 1000));
       } else {
-        var eta = '--'
+        var eta = null
+        var ttg = null
       }
-      app.debug(`what is eta: ${eta} etams: ${etams} etad: ${etad}`)
+        //      app.debug(`what is eta: ${eta} etams: ${etams} etad: ${etad}`)
 
       return [
         {
-          path: 'navigation.courseGreatCircle.nextPoint.estimatedTimeOfArrival',
-          value: eta
+          path: 'navigation.courseGreatCircle.nextPoint.estimatedTimeOfArrival', value: eta
         },
         {
-          path: 'navigation.courseGreatCircle.nextPoint.eta',
-          value: eta
+          path: 'navigation.courseGreatCircle.nextPoint.timeToGo', value: ttg
+        },
+                {
+          path: 'navigation.courseGreatCircle.nextPoint.eta', value: eta
         }
       ]
     }


### PR DESCRIPTION
in this PR:

1.  'navigation.courseGreatCircle.nextPoint.timeToGo' added a.  this is in Seconds per the spec. b.  the null value set to null vs "--"
2.  eta null value set to null vs "--"

See Forum post: https://forum.openmarine.net/showthread.php?tid=5017