### PR TITLE
Fix: estimatedTimeOfArrival, timeToGo and eta calculated incorrectly in eta.js

### DIFF
--- a/calcs/eta.js
+++ b/calcs/eta.js
@@ -19,7 +19,7 @@ module.exports = function (app) {
 
       var datems = date.getTime()
       var timetopoint = Math.floor(
-        distance / (velocityMadeGood * 0.514444) * 1000
+        distance / velocityMadeGood * 1000
       )
 
       //      app.debug(`Using datetime: ${date} ms to point : ${timetopoint} currentms: ${datems}`)


### PR DESCRIPTION
Fixes #133.

The calculation uses:
distance / (velocityMadeGood * 0.514444) * 1000

This falsely assumes that VMG is in kts when it is (and should be) in m/s.

