### PR TITLE
Add description to tank volume alternate calculation

### DIFF
--- a/calcs/tankVolume2.js
+++ b/calcs/tankVolume2.js
@@ -6,6 +6,7 @@ module.exports = function (app, plugin) {
       group: 'tanks',
       optionKey: 'tankVolume2_' + instance,
       title: 'Tank ' + instance + ' Volume',
+      title: 'Tank ' + instance + ' Volume (alternate currentVolume calculation using currentLevel and capacity, select only one calculation per tank.)',
       derivedFrom: function () {
         return [
           'tanks.' + instance + '.currentLevel',


### PR DESCRIPTION
Add description to with any confusion about the two conflicting currentVolume calculations.
Addresses issue: https://github.com/SignalK/signalk-derived-data/issues/144
