### PR TITLE
other: add description to tank volume alternate calculation

### DIFF
--- a/calcs/tankVolume2.js
+++ b/calcs/tankVolume2.js
@@ -5,7 +5,7 @@ module.exports = function (app, plugin) {
     return {
       group: 'tanks',
       optionKey: 'tankVolume2_' + instance,
-      title: 'Tank ' + instance + ' Volume',
+      title: 'Tank ' + instance + ' Volume (alternate currentVolume calculation than one above, select only one calculation per tank.) Uses ',
       derivedFrom: function () {
         return [
           'tanks.' + instance + '.currentLevel',


### PR DESCRIPTION
Add description to alternate tank calculation to help with any confusion about the two conflicting currentVolume calculations.  Addresses issue: https://github.com/SignalK/signalk-derived-data/issues/144