### PR TITLE
feature: add CPA positions to notifications

### DIFF
--- a/calcs/cpa_tcpa.js
+++ b/calcs/cpa_tcpa.js
@@ -267,6 +267,7 @@ module.exports = function (app, plugin) {
                 if (!vesselName) {
                   vesselName = mmsi || '(unknown)'
                 }
+                const cpaPositions = getCpaPositions(selfVessel, otherVessel, tcpa)
                 alarmDelta = {
                   context: 'vessels.' + app.selfId,
                   updates: [
@@ -282,6 +283,7 @@ module.exports = function (app, plugin) {
                             message: `Crossing vessel ${vesselName} ${cpa.toFixed(
                               2
                             )} m away in ${(tcpa / 60).toFixed(2)}  minutes`,
+                            cpaPositions,
                             timestamp: new Date().toISOString()
                           }
                         }
@@ -354,5 +356,12 @@ function normalAlarmDelta (vessel, mmsi) {
         ]
       }
     ]
+  }
+}
+
+function getCpaPositions(selfVessel, otherVessel, seconds) {
+  return {
+    self: geoutils.moveTo(selfVessel.location, {distance: selfVessel.speed * seconds, heading: selfVessel.heading}),
+    other: geoutils.moveTo(otherVessel.location, {distance: otherVessel.speed * seconds, heading: otherVessel.heading})
   }
 }


### PR DESCRIPTION
Add the positions of self and the other vessels to the CPA notification, so that the payload is
```
{
  "state": "alert",
  "method": [
    "visual",
    "sound"
  ],
  "message": "Crossing vessel (unknown) 86.06 m away in 10.25  minutes",
  "cpaPositions": {
    "self": {
      "lat": 60.0683170956023,
      "lon": 23.51944354234765
    },
    "other": {
      "lat": 60.06791079115338,
      "lon": 23.520767179014822
    }
  },
  "timestamp": "2025-02-20T19:26:26.649Z"
}
```