### PR TITLE
Add `okToSend` test for calculated path values.

### DIFF
--- a/calcs/windGround.js
+++ b/calcs/windGround.js
@@ -1,7 +1,16 @@
-const { formatCompassAngle } = require('../utils')
+const { formatCompassAngle, okToSend } = require('../utils')
 const _ = require('lodash')
 
-const selfData = {}
+const selfData = {
+  environment: {
+    wind: {
+      directionTrue: 0.123,
+      angleTrueGround: 0.234,
+      speedOverGround: 0.2,
+      directionGround: 0
+    }
+  }
+}
 
 module.exports = function (app, plugin) {
   return [
@@ -43,11 +52,20 @@ module.exports = function (app, plugin) {
           dir = formatCompassAngle(headTrue + angle)
         }
 
-        return [
-          { path: 'environment.wind.directionTrue', value: dir },
-          { path: 'environment.wind.angleTrueGround', value: angle },
-          { path: 'environment.wind.speedOverGround', value: speed }
-        ]
+        const r = []
+        let path = 'environment.wind.directionTrue'
+        if (okToSend(app, dir, path)) {
+          r.push({ path: path, value: dir })
+        }
+        path = 'environment.wind.angleTrueGround'
+        if (okToSend(app, angle, path)) {
+          r.push({ path: path, value: angle })
+        }
+        path = 'environment.wind.speedOverGround'
+        if (okToSend(app, speed, path)) {
+          r.push({ path: path, value: speed })
+        }
+        return r
       },
       tests: [
         {
@@ -57,6 +75,24 @@ module.exports = function (app, plugin) {
             { path: 'environment.wind.directionTrue', value: null },
             { path: 'environment.wind.angleTrueGround', value: null },
             { path: 'environment.wind.speedOverGround', value: null }
+          ]
+        },
+        {
+          input: [1.1, 0.6, 0.5, 0.2],
+          selfData,
+          expected: [
+            {
+              path: 'environment.wind.directionTrue',
+              value: 3.5069486465413533
+            },
+            {
+              path: 'environment.wind.angleTrueGround',
+              value: 2.406948646541353
+            },
+            {
+              path: 'environment.wind.speedOverGround',
+              value: 0.1481892482444493
+            }
           ]
         }
       ]
@@ -76,7 +112,12 @@ module.exports = function (app, plugin) {
 
         const wdg = formatCompassAngle(headingTrue + gwa)
 
-        return [{ path: 'environment.wind.directionGround', value: wdg }]
+        const r = []
+        const path = 'environment.wind.directionGround'
+        if (okToSend(app, wdg, path)) {
+          r.push({ path: path, value: wdg })
+        }
+        return r
       },
       tests: [
         {

--- a/utils.js
+++ b/utils.js
@@ -56,3 +56,18 @@ exports.isPosition = value => {
 
 exports.degreesToRadians = value => Math.PI / 180 * value
 exports.radiansToDegrees = value => 180 / Math.PI * value
+
+/**
+ * @description Tests new value against current path value to determine if the
+ * path new value should be emitted
+ * @param app Signal K server app
+ * @param newValue New path value
+ * @param path Path to test for the current value
+ * @returns true if new path value should be emitted
+ */
+exports.okToSend = (app, newValue, path) => {
+  const pv = app.getSelfPath(path)
+  if (!pv && newValue === null) return false
+  if (pv?.value === null && newValue === null) return false
+  return true
+}


### PR DESCRIPTION
To address the requirement that deltas not be sent for paths when the:
- calculated value = `null`  AND
- current value = `null` 
have created the `okToSend()` method for calculations to use when building a result to return.

Method has been applied to `windDirection` and `windGround` calculations.