### PR TITLE
Addition of Nautical Dawn and Nautical Dusk as published times

### DIFF
--- a/calcs/suncalc.js
+++ b/calcs/suncalc.js
@@ -43,7 +43,7 @@ module.exports = function (app, plugin) {
         } else if (now < times.nauticalDusk) {
           value = 'dusk'
           mode = 'night'
-        } else if (now < times.night {
+        } else if (now < times.night) {
           value = 'nauticalDusk'
           mode = 'night'
         } else {


### PR DESCRIPTION
I propose the changes I made to "suncalcs.js", mainly so that the plugin "signalk-bandg-displaydaynight" has more granularity available as it transitions from night to dawn.  I have been using that plugin, but the ambient light change from "Night" to "Dawn" is profound and it has been hard to get the display to be the "correct" brightness during those sholder times.
This is my first time contributing to the code on a project on github, so apologies if I did not do this correctly, however, I would gladly take any education on the right way to do it.