### PR TITLE
macneticVariation changed to WMM2025 & new data path

### DIFF
--- a/calcs/magneticVariation.js
+++ b/calcs/magneticVariation.js
@@ -24,7 +24,7 @@ module.exports = function (app, plugin) {
         String(today.getDate()).padStart(2, '0')
 
       return [
-        { path: 'navigation.magneticVariation.value', value: magVar },
+        { path: 'navigation.magneticVariation', value: magVar },
         {
           path: 'navigation.magneticVariation.source',
           value: model.name || 'WMM-2025'
@@ -40,7 +40,7 @@ module.exports = function (app, plugin) {
         input: [{ latitude: 39.0631232, longitude: -76.4872768 }],
         expectedRange: [
           {
-            path: 'navigation.magneticVariation.value',
+            path: 'navigation.magneticVariation',
             value: -0.1923,
             delta: 0.01
           }

--- a/calcs/magneticVariation.js
+++ b/calcs/magneticVariation.js
@@ -24,7 +24,7 @@ module.exports = function (app, plugin) {
         String(today.getDate()).padStart(2, '0')
 
       return [
-        { path: 'navigation.magneticVariation', value: magVar },
+        { path: 'navigation.magneticVariation.value', value: magVar },
         {
           path: 'navigation.magneticVariation.source',
           value: model.name || 'WMM-2025'
@@ -40,7 +40,7 @@ module.exports = function (app, plugin) {
         input: [{ latitude: 39.0631232, longitude: -76.4872768 }],
         expectedRange: [
           {
-            path: 'navigation.magneticVariation',
+            path: 'navigation.magneticVariation.value',
             value: -0.1923,
             delta: 0.01
           }

--- a/calcs/magneticVariation.js
+++ b/calcs/magneticVariation.js
@@ -15,13 +15,13 @@ module.exports = function (app, plugin) {
       const info = model.point([position.latitude, position.longitude])
       const magVar = info.decl * Math.PI / 180
 
-      const today = new Date()
+      const startDate = model.start_date
       const ageOfService =
-        today.getFullYear() +
+        startDate.getFullYear() +
         '.' +
-        String(today.getMonth() + 1).padStart(2, '0') +
+        String(startDate.getMonth() + 1).padStart(2, '0') +
         '.' +
-        String(today.getDate()).padStart(2, '0')
+        String(startDate.getDate()).padStart(2, '0')
 
       return [
         { path: 'navigation.magneticVariation', value: magVar },

--- a/calcs/magneticVariation.js
+++ b/calcs/magneticVariation.js
@@ -15,23 +15,11 @@ module.exports = function (app, plugin) {
       const info = model.point([position.latitude, position.longitude])
       const magVar = info.decl * Math.PI / 180
 
-      const startDate = model.start_date
-      const ageOfService =
-        startDate.getFullYear() +
-        '.' +
-        String(startDate.getMonth() + 1).padStart(2, '0') +
-        '.' +
-        String(startDate.getDate()).padStart(2, '0')
-
       return [
         { path: 'navigation.magneticVariation', value: magVar },
         {
           path: 'navigation.magneticVariation.source',
-          value: model.name || 'WMM-2025'
-        },
-        {
-          path: 'navigation.magneticVariation.ageOfService',
-          value: ageOfService
+          value: (model.name || 'WMM-2025').replace('-', ' ')
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "cubic-spline": "^1.0.4",
     "geolib": "^3.3.1",
     "geolocation-utils": "^1.2.3",
+    "geomagnetism": "^0.2.0",
     "lodash": "^4.17.4",
-    "magvar": "^1.0.3",
     "suncalc": "^1.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
To address this issue:
https://github.com/SignalK/signalk-to-nmea2000/issues/86

1. change geo model to WMM2025
2. new data path:

navigation.magneticVariation.source  as string, f.e. WMM2025 
navigation.magneticVariation.ageOfService as string f..e. 2025.11.22

Tested on SK 2.18,0