### PR TITLE
feat: upgrade baconjs from 1.x to 3.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ module.exports = function (app) {
         stream = app.streambundle.getSelfStream(key)
         /* } */
         if (calculation.defaults && calculation.defaults[index] != undefined) {
-          stream = stream.merge(Bacon.once(calculation.defaults[index]))
+          stream = stream.toProperty(calculation.defaults[index])
         }
         return stream
       }, app.streambundle)

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     }
   },
   "dependencies": {
-    "baconjs": "^1.0.1",
     "cubic-spline": "^1.0.4",
     "geolib": "^3.3.1",
     "geolocation-utils": "^1.2.3",
@@ -42,7 +41,11 @@
     "lodash": "^4.17.4",
     "suncalc": "^1.8.0"
   },
+  "peerDependencies": {
+    "baconjs": "^3.0.0"
+  },
   "devDependencies": {
+    "baconjs": "^3.0.0",
     "chai": "^4.2.0",
     "chai-json-equal": "0.0.1",
     "husky": "^0.14.3",


### PR DESCRIPTION
## Summary

Align with signalk-server which already uses baconjs ^3.0.0.

- Move baconjs from `dependencies` to `peerDependencies`
- Replace `stream.merge(Bacon.once(default))` with `stream.toProperty(default)` — Bacon 3.x delivers `once()` asynchronously which breaks the `combineWith` + `changes()` pipeline

## Manual testing

Tested against a live Signal K server v2.23.0 with a YDWG02 N2K gateway feeding real NMEA 2000 data:

- Plugin loads without "two Bacons loaded" errors
- CPA/distance calculations running for AIS targets
- Direction change alarm calculation active
- All 47 unit tests pass