### PR TITLE
fix: guard sun/moon calcs against null navigation.position

### DIFF
--- a/calcs/moon.js
+++ b/calcs/moon.js
@@ -1,5 +1,6 @@
 const suncalc = require('suncalc')
 const _ = require('lodash')
+const { isPosition } = require('../utils')
 
 module.exports = function (app, plugin) {
   return {
@@ -19,6 +20,12 @@ module.exports = function (app, plugin) {
     debounceDelay: 60 * 1000,
     calculator: function (datetime, position) {
       var date
+
+      // navigation.position is null during startup before the first GPS
+      // fix; suncalc would throw on null coordinates and crash the server.
+      if (!isPosition(position)) {
+        return
+      }
 
       if (!_.isUndefined(datetime) && datetime.length > 0) {
         date = new Date(datetime)
@@ -91,6 +98,17 @@ module.exports = function (app, plugin) {
       }
 
       return results
-    }
+    },
+    tests: [
+      {
+        input: ['2024-06-21T12:00:00Z', null]
+      },
+      {
+        input: ['2024-06-21T12:00:00Z', undefined]
+      },
+      {
+        input: ['2024-06-21T12:00:00Z', { latitude: null, longitude: null }]
+      }
+    ]
   }
 }

--- a/calcs/suncalc.js
+++ b/calcs/suncalc.js
@@ -1,5 +1,6 @@
 const suncalc = require('suncalc')
 const _ = require('lodash')
+const { isPosition } = require('../utils')
 
 module.exports = function (app, plugin) {
   return {
@@ -14,6 +15,12 @@ module.exports = function (app, plugin) {
       var value
       var mode
       var date
+
+      // navigation.position is null during startup before the first GPS
+      // fix; suncalc would throw on null coordinates and crash the server.
+      if (!isPosition(position)) {
+        return
+      }
 
       if (datetime && datetime.length > 0) {
         date = new Date(datetime)
@@ -67,6 +74,17 @@ module.exports = function (app, plugin) {
         { path: 'environment.sun', value: value },
         { path: 'environment.mode', value: mode }
       ]
-    }
+    },
+    tests: [
+      {
+        input: ['2024-06-21T12:00:00Z', null]
+      },
+      {
+        input: ['2024-06-21T12:00:00Z', undefined]
+      },
+      {
+        input: ['2024-06-21T12:00:00Z', { latitude: null, longitude: null }]
+      }
+    ]
   }
 }

--- a/calcs/suntime.js
+++ b/calcs/suntime.js
@@ -1,5 +1,6 @@
 const suncalc = require('suncalc')
 const _ = require('lodash')
+const { isPosition } = require('../utils')
 
 module.exports = function (app, plugin) {
   return {
@@ -19,6 +20,12 @@ module.exports = function (app, plugin) {
     debounceDelay: 60 * 1000,
     calculator: function (datetime, position) {
       var date
+
+      // navigation.position is null during startup before the first GPS
+      // fix; suncalc would throw on null coordinates and crash the server.
+      if (!isPosition(position)) {
+        return
+      }
 
       if (datetime && datetime.length > 0) {
         date = new Date(datetime)
@@ -64,6 +71,17 @@ module.exports = function (app, plugin) {
       }
 
       return results
-    }
+    },
+    tests: [
+      {
+        input: ['2024-06-21T12:00:00Z', null]
+      },
+      {
+        input: ['2024-06-21T12:00:00Z', undefined]
+      },
+      {
+        input: ['2024-06-21T12:00:00Z', { latitude: null, longitude: null }]
+      }
+    ]
   }
 }


### PR DESCRIPTION
Fixes #178.

## Summary
- Sun, suntime, and moon calculators dereferenced `position.latitude` unconditionally, throwing an unhandled exception whenever `navigation.position` was null (e.g. during startup before the first GPS fix). This crashed the Signal K server into a restart loop.
- Guarded all three calculators with `isPosition()` so they skip silently until a valid fix is available.
- Added null / undefined / partial-position tests for each affected calc.

## Test plan
- [x] `npm test` (56 passing, +9 new)
- [x] `npm run format`