### PR TITLE
chore: tighten dependabot actions schedule to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,11 +22,11 @@ updates:
     labels:
       - dependencies
 
-  # GitHub Actions: monthly, one grouped PR for everything
+  # GitHub Actions: weekly, one grouped PR for everything
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
-      interval: monthly
+      interval: weekly
     open-pull-requests-limit: 5
     groups:
       actions:


### PR DESCRIPTION
## Summary

Flip dependabot's `github-actions` schedule from `monthly` to `weekly` so CI action bumps land on the same cadence as npm, instead of sitting up to a month before surfacing.

This is a direct follow-up to the manual `mikepenz/release-changelog-builder-action@v5 → @v6` and `softprops/action-gh-release@v2 → @v3` bumps that just landed — those should have been dependabot PRs but weren't, because the monthly window hadn't fired yet after the config was added.

## Unification note

The base shape of `dependabot.yml` across nmea0183-signalk, nmea0183-utilities, signalk-derived-data, and signalk-to-nmea0183 is already identical. Only the per-repo `ignore:` entries differ, and each one is still justified by the repo's actual dependency state (verified against `package.json`):

- **nmea0183-signalk** — keeps `chai` major-ignore (still on chai@4 + chai-things) and `prettier` major-ignore (still on prettier@2).
- **nmea0183-utilities** — no ignores needed.
- **signalk-derived-data** — keeps `cubic-spline` major-ignore (`tankVolume.js` still on the v1 call shape).
- **signalk-to-nmea0183** — no ignores needed.

## Test plan

- [x] YAML parses
- [x] Diff is a single `interval: monthly` → `interval: weekly` + its matching comment
- [ ] Dependabot re-evaluates on merge and opens any pending action PRs within its next run window