### PR TITLE
chore(deps): bump cubic-spline to 3 and cover tankVolume

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,14 +11,6 @@ updates:
         update-types:
           - minor
           - patch
-    ignore:
-      # cubic-spline 2.x switched from a function call (spline(x, xs, ys))
-      # to a constructor + .at(x) method. calcs/tankVolume.js still uses
-      # the v1 form and has no test coverage. Re-enable after refactoring
-      # tankVolume.js and adding a test for the spline call.
-      - dependency-name: cubic-spline
-        update-types:
-          - version-update:semver-major
     labels:
       - dependencies
 

--- a/calcs/tankVolume.js
+++ b/calcs/tankVolume.js
@@ -1,4 +1,4 @@
-var spline = require('cubic-spline')
+const Spline = require('cubic-spline')
 const _ = require('lodash')
 const util = require('util') // dev
 
@@ -63,14 +63,21 @@ module.exports = function (app, plugin) {
           }
         })
 
+        // cubic-spline 2.x dropped the `spline(x, xs, ys)` function form
+        // in favour of a `new Spline(xs, ys).at(x)` constructor + method.
+        // Build the interpolator once per calculation and reuse it for
+        // both capacity (at level=1) and current volume (at the measured
+        // level).
+        const interpolator = new Spline(calLevels, calVolumes)
+
         return [
           {
             path: 'tanks.' + instance + '.capacity',
-            value: spline(1, calLevels, calVolumes)
+            value: interpolator.at(1)
           },
           {
             path: 'tanks.' + instance + '.currentVolume',
-            value: spline(level, calLevels, calVolumes)
+            value: interpolator.at(level)
           }
         ]
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.41.0",
       "license": "ISC",
       "dependencies": {
-        "cubic-spline": "^1.0.4",
+        "cubic-spline": "^3.0.3",
         "geolib": "^3.3.1",
         "geolocation-utils": "^1.2.3",
         "geomagnetism": "^0.2.0",
@@ -1231,9 +1231,9 @@
       }
     },
     "node_modules/cubic-spline": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/cubic-spline/-/cubic-spline-1.0.4.tgz",
-      "integrity": "sha512-1cLkurHMXYeqHqL5sRGroci83zb6dE+8nrEHHNBSNzH5yAagtCjSS4itgdqi/hYFgDdLXZAAqFSDJVy0kB9Siw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/cubic-spline/-/cubic-spline-3.0.3.tgz",
+      "integrity": "sha512-yAvcHgrpf/k83pZiO4+R2reWOJlufgjpQhmDD3OXa8YMbjmRgjtUK8pcFOCZvJwqXaMD1isZdL7Z4ghqDPN/yw==",
       "license": "MIT"
     },
     "node_modules/dashify": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     }
   },
   "dependencies": {
-    "cubic-spline": "^1.0.4",
+    "cubic-spline": "^3.0.3",
     "geolib": "^3.3.1",
     "geolocation-utils": "^1.2.3",
     "geomagnetism": "^0.2.0",

--- a/test/tankVolume.js
+++ b/test/tankVolume.js
@@ -1,0 +1,115 @@
+const chai = require('chai')
+chai.Should()
+const expect = chai.expect
+
+const tankVolume = require('../calcs/tankVolume')
+
+// tankVolume's calculator reads `plugin.properties.tanks` via closure
+// at call time, so the tests build a plugin with calibration data up
+// front and pass it into the factory. The existing `calc.tests` harness
+// in test/test.js doesn't support per-test plugin properties, which is
+// why this suite is standalone.
+function makePlugin (instance, volumeUnit, calibration) {
+  return {
+    tanks: [instance],
+    properties: {
+      tanks: {
+        volume_unit: volumeUnit,
+        ['calibrations.' + instance]: calibration
+      }
+    }
+  }
+}
+
+const app = { debug: () => {} }
+
+describe('tankVolume', () => {
+  // Calibration expressed as (level ratio 0..1, volume in the selected unit).
+  // For a linear tank, volume scales linearly with level, so the spline
+  // should exactly reproduce the calibration pairs at the knot points
+  // and interpolate smoothly in between.
+  const linearCalLitres = [
+    { level: 0, volume: 0 },
+    { level: 0.25, volume: 25 },
+    { level: 0.5, volume: 50 },
+    { level: 0.75, volume: 75 },
+    { level: 1, volume: 100 }
+  ]
+
+  it('produces capacity and currentVolume paths for the configured instance', () => {
+    const plugin = makePlugin('fuel.0', 'litres', linearCalLitres)
+    const calc = tankVolume(app, plugin)[0]
+
+    const result = calc.calculator(0.5)
+
+    result.should.be.an('array').with.lengthOf(2)
+    result[0].path.should.equal('tanks.fuel.0.capacity')
+    result[1].path.should.equal('tanks.fuel.0.currentVolume')
+  })
+
+  it('reports capacity as the volume at level = 1', () => {
+    const plugin = makePlugin('fuel.0', 'litres', linearCalLitres)
+    const calc = tankVolume(app, plugin)[0]
+
+    // 100 L expressed in m^3 = 0.1
+    const result = calc.calculator(0)
+    result[0].value.should.be.closeTo(0.1, 1e-9)
+  })
+
+  it('interpolates currentVolume at exact knot points', () => {
+    const plugin = makePlugin('fuel.0', 'litres', linearCalLitres)
+    const calc = tankVolume(app, plugin)[0]
+
+    // 50 L at level 0.5 -> 0.05 m^3
+    const result = calc.calculator(0.5)
+    result[1].value.should.be.closeTo(0.05, 1e-9)
+  })
+
+  it('interpolates currentVolume between knot points', () => {
+    const plugin = makePlugin('fuel.0', 'litres', linearCalLitres)
+    const calc = tankVolume(app, plugin)[0]
+
+    // Linear calibration -> level 0.375 should be ~37.5 L = 0.0375 m^3.
+    // Cubic spline may deviate slightly but should be within a few mL.
+    const result = calc.calculator(0.375)
+    result[1].value.should.be.closeTo(0.0375, 1e-3)
+  })
+
+  it('converts gallons to cubic metres', () => {
+    const gallonsCal = [
+      { level: 0, volume: 0 },
+      { level: 0.5, volume: 10 },
+      { level: 1, volume: 20 }
+    ]
+    const plugin = makePlugin('fuel.0', 'gal', gallonsCal)
+    const calc = tankVolume(app, plugin)[0]
+
+    // 20 gal * 0.00378541 m^3/gal = 0.0757082 m^3 at level = 1
+    const result = calc.calculator(1)
+    result[0].value.should.be.closeTo(0.0757082, 1e-6)
+    result[1].value.should.be.closeTo(0.0757082, 1e-6)
+  })
+
+  it('leaves m^3 calibration values unconverted', () => {
+    const m3Cal = [
+      { level: 0, volume: 0 },
+      { level: 0.5, volume: 0.125 },
+      { level: 1, volume: 0.25 }
+    ]
+    const plugin = makePlugin('fuel.0', 'm3', m3Cal)
+    const calc = tankVolume(app, plugin)[0]
+
+    const result = calc.calculator(1)
+    result[0].value.should.be.closeTo(0.25, 1e-9)
+  })
+
+  it('uses the calculator API (regression for cubic-spline v2+ API)', () => {
+    // cubic-spline 2.x removed the `spline(x, xs, ys)` function form
+    // in favour of `new Spline(xs, ys).at(x)`. A calculator call must
+    // not throw under the new API.
+    const plugin = makePlugin('fuel.0', 'litres', linearCalLitres)
+    const calc = tankVolume(app, plugin)[0]
+
+    expect(() => calc.calculator(0.5)).to.not.throw()
+  })
+})


### PR DESCRIPTION
## Summary

Unblocks the `cubic-spline` major bump that `.github/dependabot.yml` currently ignores. Supersedes #198 (closed pending this work).

`cubic-spline` 2.x dropped the v1 function form

```js
spline(x, xs, ys)
```

in favour of a constructor + method

```js
new Spline(xs, ys).at(x)
```

`calcs/tankVolume.js` was the only call site and had zero test coverage, so the bump was pinned. This PR:

- Ports `calcs/tankVolume.js` to the v3 API (builds the interpolator once per calculation and queries it at `level=1` for capacity and at the measured level for `currentVolume`).
- Adds a standalone test suite (`test/tankVolume.js`) covering output paths, capacity, knot-point + between-knot interpolation, litres/gal/m³ unit conversion, and a regression guard that the calculator does not throw under the v3 API. Written standalone because the existing `calc.tests` harness in `test/test.js` does not support per-test plugin properties.
- Bumps `cubic-spline` to `^3.0.3` and drops the major-version ignore from `.github/dependabot.yml`.

## Test plan

- [x] `npm test` — all 54 tests pass (47 existing + 7 new tankVolume tests)
- [x] Verified new tests fail on cubic-spline v1 and pass on v3, i.e. they actually exercise the refactored call sites