### PR TITLE
refactor: drop redundant guard comments in sun/moon calcs

### DIFF
--- a/calcs/moon.js
+++ b/calcs/moon.js
@@ -21,8 +21,6 @@ module.exports = function (app, plugin) {
     calculator: function (datetime, position) {
       var date
 
-      // navigation.position is null during startup before the first GPS
-      // fix; suncalc would throw on null coordinates and crash the server.
       if (!isPosition(position)) {
         return
       }

--- a/calcs/suncalc.js
+++ b/calcs/suncalc.js
@@ -16,8 +16,6 @@ module.exports = function (app, plugin) {
       var mode
       var date
 
-      // navigation.position is null during startup before the first GPS
-      // fix; suncalc would throw on null coordinates and crash the server.
       if (!isPosition(position)) {
         return
       }

--- a/calcs/suntime.js
+++ b/calcs/suntime.js
@@ -21,8 +21,6 @@ module.exports = function (app, plugin) {
     calculator: function (datetime, position) {
       var date
 
-      // navigation.position is null during startup before the first GPS
-      // fix; suncalc would throw on null coordinates and crash the server.
       if (!isPosition(position)) {
         return
       }


### PR DESCRIPTION
## Summary

Follow-up to #183. The `if (!isPosition(position)) return` guard is self-explanatory; the two-line comment above it restated what the code already shows. Removed in all three calcs.

## Test plan

- [x] \`npm test\` (63 passing)
- [x] \`prettier-standard --check\` clean