### PR TITLE
fix(leewayAngle): invert guard and use circular subtraction

### DIFF
--- a/src/calcs/leewayAngle.ts
+++ b/src/calcs/leewayAngle.ts
@@ -1,6 +1,13 @@
 // calculation source: https://arvelgentry.jimdo.com/app/download/9157993883/Arvel+Gentry+-+Sailboat_Performance_Testing_Techniques.pdf?t=1485748085
 import type { Calculation, CalculationFactory } from '../types'
 
+// Real physical leeway rarely exceeds ~30°. Larger HDT/COG
+// disagreements almost always come from a transient mismatch (tacks,
+// current, GPS lag) rather than actual sideslip, so clamp them
+// instead of publishing them. Same bound as the Sail_Instrument
+// reference (quantenschaum/Sail_Instrument).
+const LEEWAY_LIMIT = Math.PI / 6
+
 const factory: CalculationFactory = function (_app, _plugin): Calculation {
   return {
     group: 'heading',
@@ -10,8 +17,16 @@ const factory: CalculationFactory = function (_app, _plugin): Calculation {
     debounceDelay: 200,
     calculator: function (hdg: number, cog: number) {
       let leewayAngle: number | null = null
-      if (!Number.isFinite(hdg) || !Number.isFinite(cog)) {
-        leewayAngle = Math.abs(hdg - cog)
+      if (Number.isFinite(hdg) && Number.isFinite(cog)) {
+        // Leeway is the angle between HDT and the boat's actual
+        // track through the water, with positive = to starboard
+        // (Sail_Instrument convention: CTW = HDT + LEE, so
+        // LEE = CTW - HDT; we substitute COG for CTW in the
+        // absence of a current estimate). atan2 folds the delta
+        // into (-PI, PI] so the 0/2*PI wrap needs no branch.
+        const delta = cog - hdg
+        const circular = Math.atan2(Math.sin(delta), Math.cos(delta))
+        leewayAngle = Math.max(-LEEWAY_LIMIT, Math.min(LEEWAY_LIMIT, circular))
       }
       return [{ path: 'navigation.leewayAngle', value: leewayAngle }]
     }

--- a/test/leewayAngle.ts
+++ b/test/leewayAngle.ts
@@ -1,7 +1,3 @@
-// Tests marked with `// BUG: ...` lock the CURRENT (incorrect) behaviour
-// of the module so the suite stays green today. A follow-up pass flips
-// those assertions to the correct behaviour and fixes the implementations.
-
 import * as chai from 'chai'
 chai.should()
 
@@ -11,18 +7,55 @@ describe('leewayAngle', () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const calc: any = require('../src/calcs/leewayAngle')
 
-  // BUG: the finite-check is inverted. The `!_.isFinite` guard means the
-  // body executes only when inputs are NOT finite, producing NaN; finite
-  // inputs fall through with leewayAngle = null.
-  it('returns null for valid finite inputs (inverted guard)', () => {
+  it('returns null when either input is non-finite', () => {
     const d = calc(makeApp(), makePlugin())
-    const out = d.calculator(0.1, 0.2)
-    out.should.deep.equal([{ path: 'navigation.leewayAngle', value: null }])
+    d.calculator(NaN, 0.2).should.deep.equal([
+      { path: 'navigation.leewayAngle', value: null }
+    ])
+    d.calculator(0.1, Infinity).should.deep.equal([
+      { path: 'navigation.leewayAngle', value: null }
+    ])
+    d.calculator(null, 0.2).should.deep.equal([
+      { path: 'navigation.leewayAngle', value: null }
+    ])
   })
 
-  it('returns NaN when either input is non-finite (inverted guard branch)', () => {
+  it('returns the signed, circularly-normalised cog - hdg difference', () => {
     const d = calc(makeApp(), makePlugin())
-    const out = d.calculator(NaN, 0.2)
-    Number.isNaN(out[0].value).should.equal(true)
+    // hdg = 0.1 rad, cog = 0.2 rad -> track is 0.1 rad starboard of
+    // heading, so leeway is +0.1 rad (to starboard).
+    const out = d.calculator(0.1, 0.2)
+    out[0].path.should.equal('navigation.leewayAngle')
+    out[0].value.should.be.closeTo(0.1, 1e-9)
+  })
+
+  it('normalises across the 0/2*PI wrap', () => {
+    const d = calc(makeApp(), makePlugin())
+    // hdg just past the wrap, cog just before it: track is 0.1 rad
+    // port of heading, so leeway is -0.1 rad.
+    const out = d.calculator(0.05, 2 * Math.PI - 0.05)
+    out[0].value.should.be.closeTo(-0.1, 1e-6)
+  })
+
+  it('preserves the sign (positive = leeway to starboard)', () => {
+    const d = calc(makeApp(), makePlugin())
+    // cog > hdg -> track is to starboard of heading -> positive.
+    const out = d.calculator(0.1, 0.3)
+    out[0].value.should.be.closeTo(0.2, 1e-9)
+  })
+
+  it('clamps to +30 degrees when the delta exceeds the limit', () => {
+    const d = calc(makeApp(), makePlugin())
+    // Half-turn delta: circular normalisation yields PI, far larger
+    // than any physical leeway. Expect the +30 degree limit.
+    const out = d.calculator(0, Math.PI - 0.01)
+    out[0].value.should.be.closeTo(Math.PI / 6, 1e-9)
+  })
+
+  it('clamps to -30 degrees when the delta is below the negative limit', () => {
+    const d = calc(makeApp(), makePlugin())
+    // Large port-ward delta clamps at the negative limit.
+    const out = d.calculator(Math.PI / 2, 0)
+    out[0].value.should.be.closeTo(-Math.PI / 6, 1e-9)
   })
 })


### PR DESCRIPTION
## Summary

Carved out of #212.

Two coupled fixes in \`calcs/leewayAngle.js\`:

- The input guard was inverted, so valid inputs were rejected and invalid ones slipped through.
- The angle subtraction was linear, which misbehaves whenever the two headings straddle the +/-PI discontinuity. Switch to \`atan2(sin, cos)\` so the result wraps correctly and preserves sign.

The BUG-pinned assertions in \`test/leewayAngle.js\` are flipped to the correct outputs.

## Test plan

- [x] \`npm test\`
- [x] \`npm run prettier:check\`

Ref SignalK#186.