### PR TITLE
fix(steer_error): normalise via atan2(sin, cos)

### DIFF
--- a/src/calcs/steer_error.ts
+++ b/src/calcs/steer_error.ts
@@ -24,13 +24,9 @@ const factory: CalculationFactory = function (app): Calculation {
         Number.isFinite(bearingToDestinationTrue)
       ) {
         steererr = courseOverGroundTrue - bearingToDestinationTrue
-        if (steererr > Math.PI) {
-          steer = (steererr - Math.PI) * -1
-        } else if (steererr < -Math.PI) {
-          steer = (steererr + Math.PI) * -1
-        } else {
-          steer = steererr
-        }
+        // Normalise to (-PI, PI]. atan2(sin, cos) handles both the >PI
+        // and <-PI wraps with a single expression.
+        steer = Math.atan2(Math.sin(steererr), Math.cos(steererr))
 
         if (steer > 0) {
           ;((leftSteer = steer), (rightSteer = 0))

--- a/test/steer_error.ts
+++ b/test/steer_error.ts
@@ -1,7 +1,3 @@
-// Tests marked with `// BUG: ...` lock the CURRENT (incorrect) behaviour
-// of the module so the suite stays green today. A follow-up pass flips
-// those assertions to the correct behaviour and fixes the implementations.
-
 import * as chai from 'chai'
 chai.should()
 
@@ -46,21 +42,24 @@ describe('steer_error', () => {
     out[2].value.should.be.closeTo(0.5, 1e-9)
   })
 
-  // BUG: the wrap-around branch uses `(err - PI) * -1` instead of
-  // `err - 2*PI`. For COG = 5.934 rad, bearing = 0 rad (err > PI), the
-  // current code returns -2.79 rad, while the geometrically correct
-  // normalized error is -0.349 rad (≈ -20°).
-  it('wraps err > PI to the (buggy) negative-PI-flipped value', () => {
+  it('normalises err > PI back into (-PI, PI] (circular wrap)', () => {
     const d = calc(makeApp(), makePlugin())
+    // cog ≈ 340°, bearing = 0°: raw err = 5.934 rad, true signed error
+    // is ≈ -0.349 rad (turn right 20°).
     const out = d.calculator(5.934, 0)
-    // steererr = 5.934; (5.934 - PI) * -1 = -(5.934 - PI) ≈ -2.7924
-    out[0].value.should.be.closeTo(-(5.934 - Math.PI), 1e-6)
+    out[0].value.should.be.closeTo(5.934 - 2 * Math.PI, 1e-6)
+    // Right turn -> rightSteer populated, leftSteer zero.
+    out[1].value.should.equal(0)
+    out[2].value.should.be.closeTo(2 * Math.PI - 5.934, 1e-6)
   })
 
-  it('wraps err < -PI to the (buggy) negative-PI-flipped value', () => {
+  it('normalises err < -PI back into (-PI, PI] (circular wrap)', () => {
     const d = calc(makeApp(), makePlugin())
+    // cog = 0°, bearing ≈ 340°: raw err = -5.934 rad, true signed error
+    // is ≈ +0.349 rad (turn left 20°).
     const out = d.calculator(0, 5.934)
-    // steererr = -5.934; (-5.934 + PI) * -1 = 5.934 - PI ≈ 2.7924
-    out[0].value.should.be.closeTo(5.934 - Math.PI, 1e-6)
+    out[0].value.should.be.closeTo(2 * Math.PI - 5.934, 1e-6)
+    out[1].value.should.be.closeTo(2 * Math.PI - 5.934, 1e-6)
+    out[2].value.should.equal(0)
   })
 })


### PR DESCRIPTION
## Summary

Carved out of #212.

The wrap-around step in \`calcs/steer_error.js\` used \`(err - PI) * -1\`, which is a misremembered version of the standard circular normalisation and silently returns garbage whenever \`err\` is outside the normal range. Replace it with \`atan2(Math.sin(err), Math.cos(err))\` so the result is always in \`(-PI, PI]\`.

The BUG-pinned assertions in \`test/steer_error.js\` are flipped to the correct outputs.

## Test plan

- [x] \`npm test\`
- [x] \`npm run prettier:check\`

Ref SignalK#186.