### PR TITLE
fix(windShift): normalise by 2*PI and use a circular running mean

### DIFF
--- a/src/calcs/windShift.ts
+++ b/src/calcs/windShift.ts
@@ -39,13 +39,17 @@ const factory: CalculationFactory = function (app, plugin): Calculation {
 
       let values: SignalKValue[] | undefined
       app.debug('angleApparent: ' + angleApparent)
-      if (angleApparent < 0) angleApparent = angleApparent + Math.PI / 2
+      // Normalise to [0, 2*PI) so the circular-mean math below has a
+      // consistent range to work with.
+      if (angleApparent < 0) angleApparent = angleApparent + 2 * Math.PI
       app.debug('angleApparent2: ' + angleApparent)
       app.debug('alarm: ' + alarm)
       if (typeof windAvg === 'undefined') {
         windAvg = angleApparent
       } else {
-        const diff = Math.abs(windAvg - angleApparent)
+        // Smallest signed angle between the two bearings, in [0, PI].
+        const rawDiff = windAvg - angleApparent
+        const diff = Math.abs(Math.atan2(Math.sin(rawDiff), Math.cos(rawDiff)))
         app.debug('' + windAvg + ', ' + angleApparent + ', ' + diff)
         if (diff > alarm) {
           values = [
@@ -68,7 +72,12 @@ const factory: CalculationFactory = function (app, plugin): Calculation {
             values = [normalAlarmDelta()]
             alarmSent = false
           }
-          windAvg = (windAvg + angleApparent) / 2
+          // Circular mean of the previous average and the new sample.
+          windAvg = Math.atan2(
+            Math.sin(windAvg) + Math.sin(angleApparent),
+            Math.cos(windAvg) + Math.cos(angleApparent)
+          )
+          if (windAvg < 0) windAvg = windAvg + 2 * Math.PI
         }
       }
       return values

--- a/test/windShift.ts
+++ b/test/windShift.ts
@@ -62,30 +62,30 @@ describe('windShift', () => {
     out[0].value.state.should.equal('normal')
   })
 
-  // BUG: `if (angleApparent < 0) angleApparent = angleApparent + Math.PI / 2`
-  // normalises negative apparent angles by adding PI/2 (90°). A correct
-  // circular normalisation adds 2*PI. The test pins the current offset.
-  it('shifts negative apparent angles by PI/2 (current offset)', () => {
+  it('normalises negative apparent angles by adding 2*PI', () => {
     const d = fresh(0.3)
-    // With windAvg undefined, negative sample is first offset by +PI/2
-    // and becomes the seed. A subsequent positive sample that matches
-    // `-0.1 + PI/2 ≈ 1.4708` produces a zero-diff and therefore no
-    // output, proving the offset is PI/2 not 2*PI.
+    // Seed with a negative sample; the seed is normalised to +2*PI - 0.1.
+    // A subsequent sample equal to 2*PI - 0.1 yields zero diff and no
+    // emission.
     d.calculator(-0.1)
-    expect(d.calculator(-0.1 + Math.PI / 2)).to.equal(undefined)
+    expect(d.calculator(2 * Math.PI - 0.1)).to.equal(undefined)
   })
 
-  // BUG: the average of two angles is computed as a plain arithmetic
-  // mean, which is wrong near the 0/2*PI wrap. The test pins the
-  // arithmetic-mean behaviour.
-  it('uses the arithmetic mean of angles (breaks near 2*PI wrap)', () => {
-    const d = fresh(2 * Math.PI) // large threshold so no alert fires
+  it('averages angles circularly so values straddling 2*PI do not flip 180°', () => {
+    // Threshold chosen so that:
+    //  - the wrap between 0.1 and 6.2 (shortest-arc ~0.18 rad) stays
+    //    below it and does not raise an alarm;
+    //  - a regression to arithmetic averaging (windAvg = 3.15 rad)
+    //    would put step 3 at ~PI rad from 0.01 and exceed the
+    //    threshold, failing the test.
+    // Without this tighter threshold, both means returned undefined
+    // and the test would pass either way.
+    const d = fresh(0.5)
     d.calculator(0.1)
-    d.calculator(6.2)
-    // After two calls windAvg = (0.1 + 6.2) / 2 = 3.15 rad (≈ 180°),
-    // whereas the circular mean is close to 0. Probe windAvg indirectly
-    // via a third sample just shy of the arithmetic-mean result.
-    expect(d.calculator(3.15)).to.equal(undefined)
+    d.calculator(6.2) // ≈ -0.0832 rad on the circle, diff ≈ 0.18 rad
+    // Circular mean of 0.1 and 6.2 is ≈ 0.0084 rad. Pushing 0.01 is
+    // well inside the threshold and must not raise an alarm.
+    expect(d.calculator(0.01)).to.equal(undefined)
   })
 
   it('emits nothing on stop when no alarm was sent', () => {


### PR DESCRIPTION
## Summary

Carved out of #212.

Two coupled fixes in \`calcs/windShift.js\`:

- Apparent wind angles were being normalised by adding \`PI/2\`, which shifted the reference frame instead of folding the sign into a positive angle. Use \`+ 2*PI\` (modulo 2*PI) so the value stays in \`[0, 2*PI)\`.
- The running "average" was an arithmetic mean, which misbehaves when samples straddle the 0 / 2*PI seam. Replace it with a circular mean (atan2 of summed sin/cos).

The BUG-pinned assertions in \`test/windShift.js\` are flipped to the correct outputs.

## Test plan

- [x] \`npm test\`
- [x] \`npm run prettier:check\`

Ref SignalK#186.