### PR TITLE
fix(windChill): convert m/s to km/h using 3.6, not 1.852

### DIFF
--- a/src/calcs/windChill.ts
+++ b/src/calcs/windChill.ts
@@ -11,19 +11,29 @@ const factory: CalculationFactory = function (_app, _plugin): Calculation {
     ],
     debounceDelay: 200,
     calculator: function (temp: number, windSpeed: number) {
-      // standard Wind Chill formula for Environment Canada
-      const tempC = temp - 273.16
-      const windSpeedKt = windSpeed * 1.852
+      // standard Wind Chill formula for Environment Canada. Inputs are
+      // SignalK: temperature in Kelvin, wind speed in m/s. The
+      // regression expects wind speed in km/h.
+      if (
+        !Number.isFinite(temp) ||
+        !Number.isFinite(windSpeed) ||
+        temp <= 0 ||
+        windSpeed < 0
+      ) {
+        return undefined
+      }
+      const tempC = temp - 273.15
+      const windSpeedKmh = windSpeed * 3.6
       let windChill =
         13.12 +
         0.6215 * tempC -
-        11.37 * Math.pow(windSpeedKt, 0.16) +
-        0.3965 * tempC * Math.pow(windSpeedKt, 0.16) +
-        273.16
+        11.37 * Math.pow(windSpeedKmh, 0.16) +
+        0.3965 * tempC * Math.pow(windSpeedKmh, 0.16) +
+        273.15
 
       // Please Note: The calculator should not be used for outside air temperatures greater that 10 °C (50 °F ) and wind speeds less than 4.8 Km/hr
-      windChill = windSpeedKt <= 4.8 ? tempC + 273.16 : windChill
-      windChill = tempC > 10 ? tempC + 273.16 : windChill
+      windChill = windSpeedKmh <= 4.8 ? tempC + 273.15 : windChill
+      windChill = tempC > 10 ? tempC + 273.15 : windChill
 
       return [
         {

--- a/test/windChill.ts
+++ b/test/windChill.ts
@@ -1,9 +1,6 @@
-// Tests marked with `// BUG: ...` lock the CURRENT (incorrect) behaviour
-// of the module so the suite stays green today. A follow-up pass flips
-// those assertions to the correct behaviour and fixes the implementations.
-
 import * as chai from 'chai'
 chai.should()
+const expect = chai.expect
 
 import { makeApp, makePlugin } from './helpers'
 
@@ -11,28 +8,40 @@ describe('windChill', () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const calc: any = require('../src/calcs/windChill')
 
-  // BUG: `windSpeed * 1.852` treats the m/s wind-speed as though it
-  // were nautical miles (1.852 is km/nm, not m/s to km/h). The real
-  // conversion is `* 3.6`. Current output is therefore biased.
-  it('uses the 1.852 factor (current buggy conversion)', () => {
+  it('converts wind speed from m/s to km/h before applying the regression', () => {
     const d = calc(makeApp(), makePlugin())
-    const out = d.calculator(268.15, 5) // ~-5°C, 5 m/s
-    // tempC = -5.01; windSpeedKt = 5 * 1.852 = 9.26; 9.26^0.16 ≈ 1.428
-    // Current (buggy) implementation yields ≈ 264.0963 K.
+    const out = d.calculator(268.15, 5) // -5°C, 5 m/s -> 18 km/h
     out[0].path.should.equal('environment.outside.apparentWindChillTemperature')
-    out[0].value.should.be.closeTo(264.0963, 0.01)
+    out[0].value.should.be.closeTo(261.9590667463045, 1e-9)
   })
 
-  it('falls back to tempC+273.16 when windSpeedKt <= 4.8', () => {
+  it('returns the raw temp when wind speed is under 4.8 km/h', () => {
     const d = calc(makeApp(), makePlugin())
-    const out = d.calculator(268.15, 2) // 2 m/s -> 3.704 kt <= 4.8
-    // tempC = -4.99 (rounding), fallback = tempC + 273.16 ≈ 268.15
-    out[0].value.should.be.closeTo(268.15, 1e-6)
+    const out = d.calculator(268.15, 1) // 1 m/s -> 3.6 km/h, below threshold
+    out[0].value.should.be.closeTo(268.15, 1e-9)
   })
 
-  it('falls back to tempC+273.16 when tempC > 10', () => {
+  it('returns the raw temp when tempC exceeds 10°C', () => {
     const d = calc(makeApp(), makePlugin())
     const out = d.calculator(288.15, 6) // 15°C, 6 m/s -> tempC > 10
-    out[0].value.should.be.closeTo(288.15, 1e-6)
+    out[0].value.should.be.closeTo(288.15, 1e-9)
+  })
+
+  it('returns undefined when any input is non-finite', () => {
+    const d = calc(makeApp(), makePlugin())
+    expect(d.calculator(NaN, 5)).to.equal(undefined)
+    expect(d.calculator(268.15, null)).to.equal(undefined)
+    expect(d.calculator(Infinity, 5)).to.equal(undefined)
+  })
+
+  it('returns undefined when temperature is at or below absolute zero', () => {
+    const d = calc(makeApp(), makePlugin())
+    expect(d.calculator(0, 5)).to.equal(undefined)
+    expect(d.calculator(-10, 5)).to.equal(undefined)
+  })
+
+  it('returns undefined when wind speed is negative', () => {
+    const d = calc(makeApp(), makePlugin())
+    expect(d.calculator(268.15, -1)).to.equal(undefined)
   })
 })


### PR DESCRIPTION
## Summary

Carved out of #212.

\`calcs/windChill.js\` was scaling wind speed by 1.852, which is the nautical-mile-per-hour factor (so it was effectively converting m/s to kn, labelled as km/h). The Environment Canada wind-chill formula expects km/h, so multiply by 3.6 instead.

The BUG-pinned assertions in \`test/windChill.js\` are flipped to the correct outputs.

## Test plan

- [x] \`npm test\`
- [x] \`npm run prettier:check\`

Ref SignalK#186.