### PR TITLE
fix(depth): return undefined when draft is missing or result is NaN

### DIFF
--- a/src/calcs/depthBelowKeel.ts
+++ b/src/calcs/depthBelowKeel.ts
@@ -7,12 +7,23 @@ const factory: CalculationFactory = function (app): Calculation {
     title: 'Depth Below Keel (design.draft.maximum)',
     derivedFrom: ['environment.depth.belowSurface'],
     calculator: function (depthBelowSurface: number) {
-      const draft = app.getSelfPath('design.draft.value.maximum') as number
+      const draft = app.getSelfPath('design.draft.value.maximum') as
+        | number
+        | undefined
+
+      if (typeof depthBelowSurface !== 'number' || typeof draft !== 'number') {
+        return undefined
+      }
+
+      const value = depthBelowSurface - draft
+      if (Number.isNaN(value)) {
+        return undefined
+      }
 
       return [
         {
           path: 'environment.depth.belowKeel',
-          value: depthBelowSurface - draft
+          value
         }
       ]
     }

--- a/src/calcs/depthBelowSurface.ts
+++ b/src/calcs/depthBelowSurface.ts
@@ -7,12 +7,23 @@ const factory: CalculationFactory = function (app): Calculation {
     title: 'Depth Below Surface (design.draft.maximum)',
     derivedFrom: ['environment.depth.belowKeel'],
     calculator: function (depthBelowKeel: number) {
-      const draft = app.getSelfPath('design.draft.value.maximum') as number
+      const draft = app.getSelfPath('design.draft.value.maximum') as
+        | number
+        | undefined
+
+      if (typeof depthBelowKeel !== 'number' || typeof draft !== 'number') {
+        return undefined
+      }
+
+      const value = depthBelowKeel + draft
+      if (Number.isNaN(value)) {
+        return undefined
+      }
 
       return [
         {
           path: 'environment.depth.belowSurface',
-          value: depthBelowKeel + draft
+          value
         }
       ]
     }

--- a/test/depthBelowKeel.ts
+++ b/test/depthBelowKeel.ts
@@ -1,9 +1,6 @@
-// Tests marked with `// BUG: ...` lock the CURRENT (incorrect) behaviour
-// of the module so the suite stays green today. A follow-up pass flips
-// those assertions to the correct behaviour and fixes the implementations.
-
 import * as chai from 'chai'
 chai.should()
+const expect = chai.expect
 
 import { makeApp, makePlugin } from './helpers'
 
@@ -20,13 +17,26 @@ describe('depthBelowKeel', () => {
     out.should.deep.equal([{ path: 'environment.depth.belowKeel', value: 8.5 }])
   })
 
-  // BUG: no guard against undefined draft. Result becomes NaN when
-  // design.draft.value.maximum is missing. depthBelowKeel2.js shows the
-  // correct null-guard pattern.
-  it('returns NaN when draft is missing (current behaviour)', () => {
+  it('returns undefined when draft is missing', () => {
     const app = makeApp()
     const d = calc(app, makePlugin())
-    const out = d.calculator(10)
-    Number.isNaN(out[0].value).should.equal(true)
+    expect(d.calculator(10)).to.equal(undefined)
+  })
+
+  it('returns undefined when depthBelowSurface is not a number', () => {
+    const app = makeApp({
+      selfPaths: { design: { draft: { value: { maximum: 1.5 } } } }
+    })
+    const d = calc(app, makePlugin())
+    expect(d.calculator(null)).to.equal(undefined)
+    expect(d.calculator(undefined)).to.equal(undefined)
+  })
+
+  it('returns undefined when depthBelowSurface is NaN', () => {
+    const app = makeApp({
+      selfPaths: { design: { draft: { value: { maximum: 1.5 } } } }
+    })
+    const d = calc(app, makePlugin())
+    expect(d.calculator(NaN)).to.equal(undefined)
   })
 })

--- a/test/depthBelowSurface.ts
+++ b/test/depthBelowSurface.ts
@@ -1,9 +1,6 @@
-// Tests marked with `// BUG: ...` lock the CURRENT (incorrect) behaviour
-// of the module so the suite stays green today. A follow-up pass flips
-// those assertions to the correct behaviour and fixes the implementations.
-
 import * as chai from 'chai'
 chai.should()
+const expect = chai.expect
 
 import { makeApp, makePlugin } from './helpers'
 
@@ -22,10 +19,25 @@ describe('depthBelowSurface', () => {
     ])
   })
 
-  // BUG: no guard against missing draft; result becomes NaN.
-  it('returns NaN when draft is missing (current behaviour)', () => {
+  it('returns undefined when draft is missing', () => {
     const d = calc(makeApp(), makePlugin())
-    const out = d.calculator(5)
-    Number.isNaN(out[0].value).should.equal(true)
+    expect(d.calculator(5)).to.equal(undefined)
+  })
+
+  it('returns undefined when depthBelowKeel is not a number', () => {
+    const app = makeApp({
+      selfPaths: { design: { draft: { value: { maximum: 1.5 } } } }
+    })
+    const d = calc(app, makePlugin())
+    expect(d.calculator(null)).to.equal(undefined)
+    expect(d.calculator(undefined)).to.equal(undefined)
+  })
+
+  it('returns undefined when depthBelowKeel is NaN', () => {
+    const app = makeApp({
+      selfPaths: { design: { draft: { value: { maximum: 1.5 } } } }
+    })
+    const d = calc(app, makePlugin())
+    expect(d.calculator(NaN)).to.equal(undefined)
   })
 })


### PR DESCRIPTION
## Summary

Carved out of #212.

\`calcs/depthBelowKeel.js\` and \`calcs/depthBelowSurface.js\` both emitted NaN (or a bogus value) when the draft path was absent or when the arithmetic produced NaN. Both variants should swallow the sample in that case, which is what \`depthBelowKeel2\` already does. Keeps behaviour consistent across the three depth calcs.

The BUG-pinned assertions in \`test/depthBelowKeel.js\` and \`test/depthBelowSurface.js\` are flipped to the correct outputs.

## Test plan

- [x] \`npm test\`
- [x] \`npm run prettier:check\`

Ref SignalK#186.