### PR TITLE
fix(fuelConsumtion): guard zero/missing rate so economy stays finite

### DIFF
--- a/src/calcs/fuelConsumtion.ts
+++ b/src/calcs/fuelConsumtion.ts
@@ -19,6 +19,20 @@ const factory: CalculationFactory = function (app, plugin): Calculation[] {
         return derivedFromList
       },
       calculator: function (rate: number, speed: number) {
+        // Fuel rate is strictly positive (an injector can't un-burn
+        // fuel); SOG is a magnitude so it can't be negative. Treat
+        // either non-finite or non-positive rate, and any non-finite
+        // or negative speed, as "no data" so the calc silently drops
+        // the sample instead of publishing Infinity or a nonsense
+        // economy value.
+        if (
+          !Number.isFinite(rate) ||
+          rate <= 0 ||
+          !Number.isFinite(speed) ||
+          speed < 0
+        ) {
+          return undefined
+        }
         return [{ path: economyPath, value: speed / rate }]
       }
     }

--- a/test/fuelConsumtion.ts
+++ b/test/fuelConsumtion.ts
@@ -1,9 +1,6 @@
-// Tests marked with `// BUG: ...` lock the CURRENT (incorrect) behaviour
-// of the module so the suite stays green today. A follow-up pass flips
-// those assertions to the correct behaviour and fixes the implementations.
-
 import * as chai from 'chai'
 chai.should()
+const expect = chai.expect
 
 import { makeApp, makePlugin } from './helpers'
 
@@ -24,13 +21,38 @@ describe('fuelConsumtion', () => {
       ])
   })
 
-  // BUG: the calculator divides speed by rate with no guard for rate
-  // being zero or missing, producing Infinity / -Infinity.
-  it('returns speed / rate without a divide-by-zero guard', () => {
+  it('computes economy = speed / rate for valid inputs', () => {
     const arr = calc(makeApp(), makePlugin())
-    const out = arr[0].calculator(2, 10)
-    out.should.deep.equal([{ path: 'propulsion.port.fuel.economy', value: 5 }])
-    const div0 = arr[0].calculator(0, 10)
-    div0[0].value.should.equal(Infinity)
+    arr[0]
+      .calculator(2, 10)
+      .should.deep.equal([{ path: 'propulsion.port.fuel.economy', value: 5 }])
+  })
+
+  it('returns undefined when fuel rate is zero or non-finite', () => {
+    const arr = calc(makeApp(), makePlugin())
+    expect(arr[0].calculator(0, 10)).to.equal(undefined)
+    expect(arr[0].calculator(null, 10)).to.equal(undefined)
+    expect(arr[0].calculator(undefined, 10)).to.equal(undefined)
+    expect(arr[0].calculator(NaN, 10)).to.equal(undefined)
+  })
+
+  it('returns undefined when fuel rate is negative', () => {
+    // An injector can't un-burn fuel; a negative rate is a sensor
+    // glitch, not a legitimate reading.
+    const arr = calc(makeApp(), makePlugin())
+    expect(arr[0].calculator(-0.5, 10)).to.equal(undefined)
+  })
+
+  it('returns undefined when speed is non-finite', () => {
+    const arr = calc(makeApp(), makePlugin())
+    expect(arr[0].calculator(2, null)).to.equal(undefined)
+    expect(arr[0].calculator(2, undefined)).to.equal(undefined)
+  })
+
+  it('returns undefined when speed is negative', () => {
+    // SOG is a magnitude per SignalK convention; a negative value is
+    // a sensor glitch rather than astern movement.
+    const arr = calc(makeApp(), makePlugin())
+    expect(arr[0].calculator(2, -1)).to.equal(undefined)
   })
 })


### PR DESCRIPTION
## Summary

Carved out of #212.

\`calcs/fuelConsumtion.js\` divided by the fuel rate without a zero check, so economy emitted Infinity whenever the engine was idling or the rate path was missing. Guard against zero and missing values.

The BUG-pinned assertions in \`test/fuelConsumtion.js\` are flipped to the correct outputs.

## Test plan

- [x] \`npm test\`
- [x] \`npm run prettier:check\`

Ref SignalK#186.