### PR TITLE
fix(propslip): guard missing gearRatio/pitch so slip stays numeric

### DIFF
--- a/src/calcs/propslip.ts
+++ b/src/calcs/propslip.ts
@@ -46,18 +46,24 @@ const factory: CalculationFactory = function (app, plugin): Calculation[] {
       calculator: function (revolutions: number, stw: number) {
         const gearRatio = app.getSelfPath(gearRatioPath) as number | undefined
         const pitch = app.getSelfPath(pitchPath) as number | undefined
-        if (revolutions > 0) {
-          return [
-            {
-              path: slipPath,
-              value:
-                1 -
-                (stw * (gearRatio as number)) /
-                  (revolutions * (pitch as number))
-            }
-          ]
+        if (
+          !Number.isFinite(revolutions) ||
+          revolutions <= 0 ||
+          !Number.isFinite(stw) ||
+          !Number.isFinite(gearRatio) ||
+          !Number.isFinite(pitch) ||
+          pitch === 0
+        ) {
+          return undefined
         }
-        return undefined
+        return [
+          {
+            path: slipPath,
+            value:
+              1 -
+              (stw * (gearRatio as number)) / (revolutions * (pitch as number))
+          }
+        ]
       },
       tests: [
         {

--- a/test/propslip.ts
+++ b/test/propslip.ts
@@ -1,7 +1,3 @@
-// Tests marked with `// BUG: ...` lock the CURRENT (incorrect) behaviour
-// of the module so the suite stays green today. A follow-up pass flips
-// those assertions to the correct behaviour and fixes the implementations.
-
 import * as chai from 'chai'
 chai.should()
 const expect = chai.expect
@@ -43,9 +39,7 @@ describe('propslip', () => {
     out[0].value.should.be.closeTo(0.5, 1e-9)
   })
 
-  // BUG: missing null-check on pitch and gearRatio. If either is
-  // undefined, the formula emits NaN instead of returning undefined.
-  it('emits NaN when gearRatio is missing', () => {
+  it('returns undefined when gearRatio is missing', () => {
     const app = makeApp({
       selfPaths: {
         propulsion: {
@@ -54,11 +48,10 @@ describe('propslip', () => {
       }
     })
     const arr = calc(app, makePlugin())
-    const out = arr[0].calculator(2, 1)
-    Number.isNaN(out[0].value).should.equal(true)
+    expect(arr[0].calculator(2, 1)).to.equal(undefined)
   })
 
-  it('emits NaN when pitch is missing', () => {
+  it('returns undefined when pitch is missing', () => {
     const app = makeApp({
       selfPaths: {
         propulsion: {
@@ -67,7 +60,22 @@ describe('propslip', () => {
       }
     })
     const arr = calc(app, makePlugin())
-    const out = arr[0].calculator(2, 1)
-    Number.isNaN(out[0].value).should.equal(true)
+    expect(arr[0].calculator(2, 1)).to.equal(undefined)
+  })
+
+  it('returns undefined when speedThroughWater is not finite', () => {
+    const app = makeApp({
+      selfPaths: {
+        propulsion: {
+          port: {
+            transmission: { gearRatio: { value: 1 } },
+            drive: { propeller: { pitch: { value: 1 } } }
+          }
+        }
+      }
+    })
+    const arr = calc(app, makePlugin())
+    expect(arr[0].calculator(2, null)).to.equal(undefined)
+    expect(arr[0].calculator(2, undefined)).to.equal(undefined)
   })
 })


### PR DESCRIPTION
## Summary

Carved out of #212.

\`calcs/propslip.js\` divided by gearRatio and pitch without a zero/missing check, so slip emitted NaN whenever those inputs were absent (typical on first-run installs with no propulsion defaults). Guard both so the calc quietly drops the sample instead of publishing NaN.

The BUG-pinned assertions in \`test/propslip.js\` are flipped to the correct outputs.

## Test plan

- [x] \`npm test\`
- [x] \`npm run prettier:check\`

Ref SignalK#186.