### PR TITLE
fix(cpa_tcpa): stale check reads the .timestamp path, not the parent

### DIFF
--- a/src/calcs/cpa_tcpa.ts
+++ b/src/calcs/cpa_tcpa.ts
@@ -322,21 +322,13 @@ const factory: CalculationFactory = function (app, plugin): Calculation {
             continue
           } // if distance outside range, don't calculate
 
-          // NB: these stale-check reads target the parent node (not
-          // `.timestamp`) to match the pre-refactor behaviour — the companion
-          // bug fix is tracked separately in PR #223 so it doesn't bundle
-          // with this perf change.
           if (
             isStale(
               currentMs,
-              nav.courseOverGroundTrue as unknown as string | undefined,
+              nav.courseOverGroundTrue?.timestamp,
               timelimit
             ) ||
-            isStale(
-              currentMs,
-              nav.speedOverGround as unknown as string | undefined,
-              timelimit
-            )
+            isStale(currentMs, nav.speedOverGround?.timestamp, timelimit)
           ) {
             app.debug('old course data from vessel, not calculating CPA')
             const vCourseVal = app.getPath(

--- a/test/cpa_tcpa.ts
+++ b/test/cpa_tcpa.ts
@@ -296,12 +296,7 @@ describe('cpa_tcpa', () => {
     expect(nullCpa.updates[0].values[0].value).to.equal(null)
   })
 
-  // BUG: the stale-check for course/speed reads
-  // `vessels.<id>.navigation.courseOverGroundTrue` instead of
-  // `...courseOverGroundTrue.timestamp`, so the branch only fires when
-  // the entry under that path is already a bare ISO string (which only
-  // happens via external feeders that write the parent node directly).
-  it('pushes a null CPA delta when course/speed entries are bare ISO strings older than the timelimit', () => {
+  it('pushes a null CPA delta when course/speed timestamps are older than the timelimit', () => {
     const vessels = {
       other: {
         navigation: {
@@ -309,10 +304,8 @@ describe('cpa_tcpa', () => {
             value: { latitude: 0.0001, longitude: 0 },
             timestamp: iso()
           },
-          // Bare ISO strings so the (buggy) stale lookup returns a
-          // parseable value.
-          courseOverGroundTrue: iso(-120),
-          speedOverGround: iso(-120)
+          courseOverGroundTrue: { value: 0, timestamp: iso(-120) },
+          speedOverGround: { value: 0, timestamp: iso(-120) }
         }
       }
     }
@@ -580,10 +573,14 @@ describe('cpa_tcpa — remaining branches', () => {
             value: { latitude: 0.001, longitude: 0 },
             timestamp: new Date().toISOString()
           },
-          // Bare ISO strings so the (buggy) stale lookup parses a time.
-          courseOverGroundTrue: new Date(Date.now() - 120000).toISOString(),
-          speedOverGround: new Date(Date.now() - 120000).toISOString()
-          // no .value nested paths -> vesselCourse/vesselSpeed === null
+          courseOverGroundTrue: {
+            value: null,
+            timestamp: new Date(Date.now() - 120000).toISOString()
+          },
+          speedOverGround: {
+            value: null,
+            timestamp: new Date(Date.now() - 120000).toISOString()
+          }
         }
       }
     }
@@ -592,16 +589,7 @@ describe('cpa_tcpa — remaining branches', () => {
       error: () => {},
       selfId: 'self',
       handleMessage: () => {},
-      getPath: (p: string): any => {
-        // Course/speed .value lookups must return null explicitly so the
-        // inner `!== null` branch is false and no delta is pushed.
-        if (
-          p === 'vessels.other.navigation.courseOverGroundTrue.value' ||
-          p === 'vessels.other.navigation.speedOverGround.value'
-        )
-          return null
-        return getPath({ vessels }, p)
-      },
+      getPath: (p: string): any => getPath({ vessels }, p),
       getSelfPath: () => undefined
     }
     const d = calcFactory(app, makePlugin())


### PR DESCRIPTION
## Summary

Carved out of #212.

The staleness check on the target's course and speed in \`calcs/cpa_tcpa.js\` was reading the parent path rather than its \`.timestamp\`, which always evaluated truthy and made the stale branch unreachable for conformant feeders. Read the actual \`.timestamp\` field.

The BUG-pinned assertions in \`test/cpa_tcpa.js\` are flipped to the correct outputs.

## Test plan

- [x] \`npm test\`
- [x] \`npm run prettier:check\`

Ref SignalK#186.