### PR TITLE
fix(index): tolerate missing traffic section in plugin.start config

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,6 +62,9 @@ module.exports = function (app) {
     if (!plugin.properties.air_instances) {
       plugin.properties.air_instances = defaultAir
     }
+    if (!plugin.properties.traffic) {
+      plugin.properties.traffic = {}
+    }
     if (!plugin.properties.traffic.notificationZones) {
       plugin.properties.traffic.notificationZones = []
     }

--- a/test/integration/plugin-start.js
+++ b/test/integration/plugin-start.js
@@ -43,9 +43,14 @@ function makeApp() {
 }
 
 describe('plugin.start() stream pipeline', function () {
-  // NOTE: the "does not throw when the traffic config section is missing
-  // entirely" case depends on the index.js guard introduced by PR #212.
-  // It lives on that branch, not here.
+  it('does not throw when the traffic config section is missing entirely', () => {
+    const { app } = makeApp()
+    const plugin = require('../..')(app)
+    // A fresh install saves an empty config; plugin.start must not
+    // crash just because the `traffic` section has not been created.
+    ;(() => plugin.start({ depth: { belowKeel: true } })).should.not.throw()
+    plugin.stop()
+  })
 
   it('starts and emits for a single-input calc (depthBelowKeel)', (done) => {
     const { app, streams, handled } = makeApp()
@@ -279,17 +284,5 @@ describe('plugin.start() stream pipeline', function () {
         done(e)
       }
     }, 100)
-  })
-
-  it('initialises traffic.notificationZones to [] when the key is absent', () => {
-    // Covers the `if (!plugin.properties.traffic.notificationZones)` fallback
-    // in plugin.start — the traffic section exists but the zones list is
-    // missing (e.g. a pre-notificationZones config).
-    const { app } = makeApp()
-    const plugin = require('../..')(app)
-    const props = { traffic: { sendNotifications: true } }
-    plugin.start(props)
-    props.traffic.notificationZones.should.deep.equal([])
-    plugin.stop()
   })
 })

--- a/test/integration/plugin-start.js
+++ b/test/integration/plugin-start.js
@@ -52,6 +52,18 @@ describe('plugin.start() stream pipeline', function () {
     plugin.stop()
   })
 
+  it('initialises traffic.notificationZones to [] when the key is absent', () => {
+    // Covers the `if (!plugin.properties.traffic.notificationZones)` arm,
+    // i.e. `traffic` is set but the zones list is missing (e.g. a
+    // pre-notificationZones config migrated forward).
+    const { app } = makeApp()
+    const plugin = require('../..')(app)
+    const props = { traffic: { sendNotifications: true } }
+    plugin.start(props)
+    props.traffic.notificationZones.should.deep.equal([])
+    plugin.stop()
+  })
+
   it('starts and emits for a single-input calc (depthBelowKeel)', (done) => {
     const { app, streams, handled } = makeApp()
     const plugin = require('../..')(app)


### PR DESCRIPTION
## Summary

Carved out of #212.

A fresh install hands \`plugin.start\` a props object that has no \`traffic\` section at all. The previous code dereferenced \`props.traffic.notificationZones\` unconditionally and threw on the first run. Guard the read so a missing section is treated the same as an empty zone list.

Adds an integration-level assertion to \`test/integration/plugin-start.js\` covering the no-traffic-section case.

## Test plan

- [x] \`npm test\`
- [x] \`npm run prettier:check\`

Ref SignalK#186.