### PR TITLE
fix(airDensity): guard against non-finite and absolute-zero inputs

### DIFF
--- a/calcs/airDensity.js
+++ b/calcs/airDensity.js
@@ -1,3 +1,5 @@
+const _ = require('lodash')
+
 module.exports = function (app, plugin) {
   return {
     group: 'air',
@@ -13,6 +15,14 @@ module.exports = function (app, plugin) {
       // pressure is Pa. Saturation pressure via Tetens comes out in
       // hPa, so it is multiplied by 100 before being used alongside
       // the pressure input.
+      if (
+        !_.isFinite(temp) ||
+        !_.isFinite(hum) ||
+        !_.isFinite(press) ||
+        temp <= 0
+      ) {
+        return undefined
+      }
       var tempC = temp - 273.15
       var psat = 6.1078 * Math.pow(10, (7.5 * tempC) / (tempC + 237.3)) * 100
       var pv = hum * psat

--- a/test/airDensity.js
+++ b/test/airDensity.js
@@ -35,4 +35,18 @@ describe('airDensity', () => {
     // ISA dry air at 15°C, 1013.25 hPa = 1.225 kg/m³
     out[0].value.should.be.closeTo(1.225, 1e-3)
   })
+
+  it('returns undefined when any input is non-finite', () => {
+    const d = calc(makeApp(), makePlugin())
+    expect(d.calculator(NaN, 0.5, 101325)).to.equal(undefined)
+    expect(d.calculator(298.15, null, 101325)).to.equal(undefined)
+    expect(d.calculator(298.15, 0.5, undefined)).to.equal(undefined)
+    expect(d.calculator(Infinity, 0.5, 101325)).to.equal(undefined)
+  })
+
+  it('returns undefined when temperature is at or below absolute zero', () => {
+    const d = calc(makeApp(), makePlugin())
+    expect(d.calculator(0, 0.5, 101325)).to.equal(undefined)
+    expect(d.calculator(-10, 0.5, 101325)).to.equal(undefined)
+  })
 })


### PR DESCRIPTION
## Summary

Follow-up to #213. Adds \`_.isFinite\` checks on \`temp\`/\`hum\`/\`press\` and a \`temp <= 0\` rejection so the calc returns \`undefined\` on bad input instead of emitting NaN. Matches the guard pattern already used by \`depthBelowKeel\`, \`fuelConsumtion\` and \`propslip\`.

Spotted during a post-merge sweep prompted by cross-checking the calc against the Sail_Instrument reference; other calcs all guard, air density was the outlier.

## Test plan

- [x] \`npm test\`
- [x] \`npm run prettier:check\`