### PR TITLE
perf(cpa_tcpa): loop-level optimizations on the AIS inner loop

### DIFF
--- a/calcs/cpa_tcpa.js
+++ b/calcs/cpa_tcpa.js
@@ -2,7 +2,6 @@ const _ = require('lodash')
 const geolib = require('geolib')
 const geoutils = require('geolocation-utils')
 
-var alarmSent = {}
 var notificationLevels = ['normal', 'alert', 'warn', 'alarm', 'emergency']
 
 // 1deg of latitude is ~111319 m everywhere; 1deg of longitude is that times
@@ -11,7 +10,21 @@ var notificationLevels = ['normal', 'alert', 'warn', 'alarm', 'emergency']
 // configured range cannot possibly be within range.
 const METERS_PER_DEG = 111319
 
+// Minimum change (m) that triggers a new distanceToSelf emission. Smaller
+// wobble on the GPS fix no longer causes a per-tick duplicate delta for
+// every visible AIS target.
+const DISTANCE_TO_SELF_EPSILON = 1
+
 module.exports = function (app, plugin) {
+  // Per-instance state — not module scope — so the plugin can be stopped
+  // and restarted cleanly (and so tests that share `require` don't leak
+  // alarm/distance caches between suites).
+  const alarmSent = {}
+  // Last distanceToSelf value emitted per vessel, keyed by vessel id. Reset
+  // to `undefined` when we emit a null delta (stale branch) so a subsequent
+  // re-appearance is treated as a fresh emission.
+  const lastDistanceToSelf = {}
+
   // Parses a SignalK timestamp (ISO string on the node, or undefined) and
   // returns true when older than `timelimitSec`. Missing/unparseable
   // timestamps are treated as stale so misconfigured feeders don't produce
@@ -193,6 +206,7 @@ module.exports = function (app, plugin) {
                 }
               ]
             })
+            delete lastDistanceToSelf[vessel]
           }
           continue
         } // old data from vessel, not calculating
@@ -225,20 +239,27 @@ module.exports = function (app, plugin) {
           )
 
           if (distanceToSelfEnabled) {
-            app.debug('distance of ' + vessel + ' to self: ' + distance)
-            app.handleMessage(plugin.id, {
-              context: 'vessels.' + vessel,
-              updates: [
-                {
-                  values: [
-                    {
-                      path: 'navigation.distanceToSelf',
-                      value: distance
-                    }
-                  ]
-                }
-              ]
-            })
+            const previous = lastDistanceToSelf[vessel]
+            if (
+              previous === undefined ||
+              Math.abs(distance - previous) >= DISTANCE_TO_SELF_EPSILON
+            ) {
+              app.debug('distance of ' + vessel + ' to self: ' + distance)
+              app.handleMessage(plugin.id, {
+                context: 'vessels.' + vessel,
+                updates: [
+                  {
+                    values: [
+                      {
+                        path: 'navigation.distanceToSelf',
+                        value: distance
+                      }
+                    ]
+                  }
+                ]
+              })
+              lastDistanceToSelf[vessel] = distance
+            }
           }
 
           if (distance >= range && rangeActive) {

--- a/calcs/cpa_tcpa.js
+++ b/calcs/cpa_tcpa.js
@@ -5,6 +5,12 @@ const geoutils = require('geolocation-utils')
 var alarmSent = {}
 var notificationLevels = ['normal', 'alert', 'warn', 'alarm', 'emergency']
 
+// 1deg of latitude is ~111319 m everywhere; 1deg of longitude is that times
+// cos(lat). max(dLatDeg*M, dLonDeg*M*cos(lat)) is a strict lower bound on
+// the great-circle distance, so a vessel whose coarse delta exceeds the
+// configured range cannot possibly be within range.
+const METERS_PER_DEG = 111319
+
 module.exports = function (app, plugin) {
   // Parses a SignalK timestamp (ISO string on the node, or undefined) and
   // returns true when older than `timelimitSec`. Missing/unparseable
@@ -130,6 +136,7 @@ module.exports = function (app, plugin) {
       const selfId = app.selfId
       const selfLat = selfPosition.latitude
       const selfLon = selfPosition.longitude
+      const cosSelfLat = Math.cos((selfLat * Math.PI) / 180)
       const selfCourseDeg = geoutils.radToDeg(selfCourse)
       const selfVessel = {
         location: { lon: selfLon, lat: selfLat },
@@ -192,6 +199,23 @@ module.exports = function (app, plugin) {
 
         const vesselPos = posNode && posNode.value
         if (typeof vesselPos !== 'undefined') {
+          // Cheap lower-bound filter: when a positive range is configured,
+          // skip vessels whose coarse lat/lon delta already exceeds it.
+          // Avoids the geolib haversine call (and the distanceToSelf emit)
+          // for clearly-out-of-range AIS targets on busy feeds. range<0
+          // disables the range filter entirely so we keep the old full-fat
+          // path for that opt-in.
+          if (rangeActive) {
+            const dLatMeters =
+              Math.abs(vesselPos.latitude - selfLat) * METERS_PER_DEG
+            if (dLatMeters > range) continue
+            const dLonMeters =
+              Math.abs(vesselPos.longitude - selfLon) *
+              METERS_PER_DEG *
+              cosSelfLat
+            if (dLonMeters > range) continue
+          }
+
           var distance = geolib.getDistance(
             {
               latitude: selfLat,

--- a/calcs/cpa_tcpa.js
+++ b/calcs/cpa_tcpa.js
@@ -141,6 +141,15 @@ module.exports = function (app, plugin) {
       const currentlyActiveNotifications = {}
       const currentMs = currentTimeMs()
 
+      // Scratch object mutated per vessel — `geoutils.cpa` treats its inputs
+      // as read-only, so reusing one allocation across the loop saves a
+      // per-vessel `{ location: {}, ... }` allocation on every tick.
+      const otherVessel = {
+        location: { lon: 0, lat: 0 },
+        speed: 0,
+        heading: 0
+      }
+
       for (var vessel in vesselList) {
         var cpa, tcpa
         if (vessel == selfId) {
@@ -244,15 +253,10 @@ module.exports = function (app, plugin) {
             nav.courseOverGroundTrue && nav.courseOverGroundTrue.value
           const vesselSpeed = nav.speedOverGround && nav.speedOverGround.value
           if (!_.isUndefined(vesselCourse) && !_.isUndefined(vesselSpeed)) {
-            var vesselCourseDeg = geoutils.radToDeg(vesselCourse)
-            var otherVessel = {
-              location: {
-                lon: vesselPos.longitude,
-                lat: vesselPos.latitude
-              },
-              speed: vesselSpeed, // meters/second
-              heading: vesselCourseDeg // degrees
-            }
+            otherVessel.location.lon = vesselPos.longitude
+            otherVessel.location.lat = vesselPos.latitude
+            otherVessel.speed = vesselSpeed // meters/second
+            otherVessel.heading = geoutils.radToDeg(vesselCourse) // degrees
 
             const obj = geoutils.cpa(selfVessel, otherVessel)
             tcpa = obj.time
@@ -262,23 +266,16 @@ module.exports = function (app, plugin) {
               let alarmDelta
               let notificationLevelIndex = 0
               if (cpa != null && tcpa != null && tcpa > 0) {
-                notificationZones
-                  .filter(
-                    (notificationZone) => notificationZone.active === true
-                  )
-                  .forEach((notificationZone) => {
-                    if (
-                      cpa <= notificationZone.range &&
-                      tcpa <= notificationZone.timeLimit
-                    ) {
-                      var newNotificationLevelIndex =
-                        notificationLevels.indexOf(notificationZone.level)
-                      notificationLevelIndex =
-                        newNotificationLevelIndex > notificationLevelIndex
-                          ? newNotificationLevelIndex
-                          : notificationLevelIndex
+                for (let zi = 0; zi < notificationZones.length; zi++) {
+                  const zone = notificationZones[zi]
+                  if (zone.active !== true) continue
+                  if (cpa <= zone.range && tcpa <= zone.timeLimit) {
+                    const zoneLevel = notificationLevels.indexOf(zone.level)
+                    if (zoneLevel > notificationLevelIndex) {
+                      notificationLevelIndex = zoneLevel
                     }
-                  })
+                  }
+                }
               }
               if (notificationLevelIndex > 0) {
                 var mmsi = vesselData.mmsi

--- a/calcs/cpa_tcpa.js
+++ b/calcs/cpa_tcpa.js
@@ -223,10 +223,12 @@ module.exports = function (app, plugin) {
             const dLatMeters =
               Math.abs(vesselPos.latitude - selfLat) * METERS_PER_DEG
             if (dLatMeters > range) continue
-            const dLonMeters =
-              Math.abs(vesselPos.longitude - selfLon) *
-              METERS_PER_DEG *
-              cosSelfLat
+            // Longitude wraps at ±180 — take the shorter of the two arcs so
+            // a vessel at -179.9 vs self at 179.9 is treated as ~0.2deg apart
+            // (the actual great-circle distance) instead of ~359.8deg.
+            let dLonDeg = Math.abs(vesselPos.longitude - selfLon)
+            if (dLonDeg > 180) dLonDeg = 360 - dLonDeg
+            const dLonMeters = dLonDeg * METERS_PER_DEG * cosSelfLat
             if (dLonMeters > range) continue
           }
 

--- a/calcs/cpa_tcpa.js
+++ b/calcs/cpa_tcpa.js
@@ -6,22 +6,23 @@ var alarmSent = {}
 var notificationLevels = ['normal', 'alert', 'warn', 'alarm', 'emergency']
 
 module.exports = function (app, plugin) {
-  const secondsSinceVesselUpdate = (vessel, path) => {
-    const _vesselTimestamp = app.getPath('vessels.' + vessel + '.' + path)
-    if (!_vesselTimestamp) {
-      return Date.now() / 1000
-    }
-    const vesselTimestamp = new Date(_vesselTimestamp).getTime()
+  // Parses a SignalK timestamp (ISO string on the node, or undefined) and
+  // returns true when older than `timelimitSec`. Missing/unparseable
+  // timestamps are treated as stale so misconfigured feeders don't produce
+  // phantom "fresh" data.
+  function isStale(currentMs, timestampRaw, timelimitSec) {
+    if (!timestampRaw) return true
+    const t = new Date(timestampRaw).getTime()
+    if (!Number.isFinite(t)) return false // non-parsing node (object) -> not stale
+    return Math.floor((currentMs - t) / 1000) > timelimitSec
+  }
 
-    let currentTime
-    const currentTimeString = app.getSelfPath('navigation.datetime.value')
-    if (currentTimeString) {
-      currentTime = new Date(currentTimeString).getTime()
-    } else {
-      currentTime = Date.now()
-    }
-
-    return Math.floor((currentTime - vesselTimestamp) / 1e3)
+  // Resolve the per-tick reference clock once, using the self vessel's
+  // reported navigation.datetime when present (lets the plugin stay honest
+  // when the host clock drifts vs. GPS time) and falling back to Date.now().
+  function currentTimeMs() {
+    const s = app.getSelfPath('navigation.datetime.value')
+    return s ? new Date(s).getTime() : Date.now()
   }
 
   return {
@@ -118,31 +119,50 @@ module.exports = function (app, plugin) {
       app.debug('stopped')
     },
     calculator: function (selfPosition, selfCourse, selfSpeed) {
-      var selfCourseDeg = geoutils.radToDeg(selfCourse)
-      var selfVessel = {
-        location: { lon: selfPosition.longitude, lat: selfPosition.latitude },
+      const traffic = plugin.properties.traffic
+      const range = traffic.range
+      const rangeActive = range >= 0
+      const timelimit = traffic.timelimit
+      const distanceToSelfEnabled = traffic.distanceToSelf
+      const sendNotifications =
+        _.isUndefined(traffic.sendNotifications) || traffic.sendNotifications
+      const notificationZones = traffic.notificationZones
+      const selfId = app.selfId
+      const selfLat = selfPosition.latitude
+      const selfLon = selfPosition.longitude
+      const selfCourseDeg = geoutils.radToDeg(selfCourse)
+      const selfVessel = {
+        location: { lon: selfLon, lat: selfLat },
         speed: selfSpeed, // meters/second
         heading: selfCourseDeg // degrees
       }
-      var vesselList = app.getPath('vessels')
-      var deltas = []
+      const vesselList = app.getPath('vessels')
+      const deltas = []
       const currentlyActiveNotifications = {}
+      const currentMs = currentTimeMs()
+
       for (var vessel in vesselList) {
         var cpa, tcpa
-        if (typeof vessel === 'undefined' || vessel == app.selfId) {
+        if (vessel == selfId) {
           continue
         }
 
-        if (
-          secondsSinceVesselUpdate(vessel, 'navigation.position.timestamp') >
-          plugin.properties.traffic.timelimit
-        ) {
+        const vesselData = vesselList[vessel]
+        if (!vesselData) {
+          continue
+        }
+        const nav = vesselData.navigation
+        if (!nav) {
+          continue
+        }
+        const posNode = nav.position
+        const posTimestamp = posNode && posNode.timestamp
+
+        if (isStale(currentMs, posTimestamp, timelimit)) {
           app.debug('old position of vessel, not calculating')
-          if (
-            app.getPath(
-              'vessels.' + vessel + '.navigation.distanceToSelf.value'
-            ) !== null
-          ) {
+          const currentDistanceToSelf =
+            nav.distanceToSelf && nav.distanceToSelf.value
+          if (currentDistanceToSelf !== null) {
             deltas.push({
               context: 'vessels.' + vessel,
               updates: [
@@ -161,19 +181,17 @@ module.exports = function (app, plugin) {
           continue
         } // old data from vessel, not calculating
 
-        var vesselPos = app.getPath(
-          'vessels.' + vessel + '.navigation.position.value'
-        )
+        const vesselPos = posNode && posNode.value
         if (typeof vesselPos !== 'undefined') {
           var distance = geolib.getDistance(
             {
-              latitude: selfPosition.latitude,
-              longitude: selfPosition.longitude
+              latitude: selfLat,
+              longitude: selfLon
             },
             { latitude: vesselPos.latitude, longitude: vesselPos.longitude }
           )
 
-          if (plugin.properties.traffic.distanceToSelf) {
+          if (distanceToSelfEnabled) {
             app.debug('distance of ' + vessel + ' to self: ' + distance)
             app.handleMessage(plugin.id, {
               context: 'vessels.' + vessel,
@@ -190,31 +208,27 @@ module.exports = function (app, plugin) {
             })
           }
 
-          if (
-            distance >= plugin.properties.traffic.range &&
-            plugin.properties.traffic.range >= 0
-          ) {
+          if (distance >= range && rangeActive) {
             app.debug('distance outside range, dont calculate')
             continue
           } // if distance outside range, don't calculate
 
-          var vesselCourse = app.getPath(
-            'vessels.' + vessel + '.navigation.courseOverGroundTrue.value'
-          )
-          var vesselSpeed = app.getPath(
-            'vessels.' + vessel + '.navigation.speedOverGround.value'
-          )
-
+          // NB: these stale-check reads target the parent node (not
+          // `.timestamp`) to match the pre-refactor behaviour — the companion
+          // bug fix is tracked separately in PR #223 so it doesn't bundle
+          // with this perf change.
           if (
-            secondsSinceVesselUpdate(
-              vessel,
-              'navigation.courseOverGroundTrue'
-            ) > plugin.properties.traffic.timelimit ||
-            secondsSinceVesselUpdate(vessel, 'navigation.speedOverGround') >
-              plugin.properties.traffic.timelimit
+            isStale(currentMs, nav.courseOverGroundTrue, timelimit) ||
+            isStale(currentMs, nav.speedOverGround, timelimit)
           ) {
             app.debug('old course data from vessel, not calculating CPA')
-            if (vesselCourse !== null || vesselSpeed !== null) {
+            const vCourseVal = app.getPath(
+              'vessels.' + vessel + '.navigation.courseOverGroundTrue.value'
+            )
+            const vSpeedVal = app.getPath(
+              'vessels.' + vessel + '.navigation.speedOverGround.value'
+            )
+            if (vCourseVal !== null || vSpeedVal !== null) {
               deltas.push({
                 context: 'vessels.' + vessel,
                 updates: [
@@ -226,6 +240,9 @@ module.exports = function (app, plugin) {
             }
             continue
           }
+          const vesselCourse =
+            nav.courseOverGroundTrue && nav.courseOverGroundTrue.value
+          const vesselSpeed = nav.speedOverGround && nav.speedOverGround.value
           if (!_.isUndefined(vesselCourse) && !_.isUndefined(vesselSpeed)) {
             var vesselCourseDeg = geoutils.radToDeg(vesselCourse)
             var otherVessel = {
@@ -241,14 +258,11 @@ module.exports = function (app, plugin) {
             tcpa = obj.time
             cpa = obj.distance
 
-            if (
-              _.isUndefined(plugin.properties.traffic.sendNotifications) ||
-              plugin.properties.traffic.sendNotifications
-            ) {
+            if (sendNotifications) {
               let alarmDelta
               let notificationLevelIndex = 0
               if (cpa != null && tcpa != null && tcpa > 0) {
-                plugin.properties.traffic.notificationZones
+                notificationZones
                   .filter(
                     (notificationZone) => notificationZone.active === true
                   )
@@ -267,9 +281,9 @@ module.exports = function (app, plugin) {
                   })
               }
               if (notificationLevelIndex > 0) {
-                var mmsi = app.getPath('vessels.' + vessel + '.mmsi')
+                var mmsi = vesselData.mmsi
                 app.debug('sending CPA alarm for ' + vessel)
-                let vesselName = app.getPath('vessels.' + vessel + '.name')
+                let vesselName = vesselData.name
                 if (!vesselName) {
                   vesselName = mmsi || '(unknown)'
                 }
@@ -279,7 +293,7 @@ module.exports = function (app, plugin) {
                   tcpa
                 )
                 alarmDelta = {
-                  context: 'vessels.' + app.selfId,
+                  context: 'vessels.' + selfId,
                   updates: [
                     {
                       values: [
@@ -308,7 +322,7 @@ module.exports = function (app, plugin) {
               } else {
                 if (alarmSent[vessel]) {
                   app.debug(`Clearing alarm for ${vessel}`)
-                  alarmDelta = normalAlarmDelta(app.selfId, vessel)
+                  alarmDelta = normalAlarmDelta(selfId, vessel)
                   delete alarmSent[vessel]
                 }
               }
@@ -334,7 +348,7 @@ module.exports = function (app, plugin) {
         .filter((vessel) => !currentlyActiveNotifications[vessel])
         .forEach((vessel) => {
           app.debug(`Clearing alarm for ${vessel}`)
-          deltas.push(normalAlarmDelta(app.selfId, vessel))
+          deltas.push(normalAlarmDelta(selfId, vessel))
           delete alarmSent[vessel]
         })
 

--- a/test/cpa_tcpa.js
+++ b/test/cpa_tcpa.js
@@ -188,6 +188,58 @@ describe('cpa_tcpa', () => {
       .should.have.length(2)
   })
 
+  it('cheap-reject handles longitude wraparound across the ±180 meridian', () => {
+    // Self at 179.9, vessel at -179.9 => great-circle arc is ~0.2deg
+    // (~22km), well outside 1852m range, but the NAIVE abs(lon1-lon2)=359.8
+    // would falsely accept the vessel into the cheap-reject window and fall
+    // through to geolib (where the real distance also rejects it). The wrap
+    // branch flips this so we still reject cheaply.
+    const handled = []
+    const vessels = {
+      other: {
+        navigation: {
+          position: {
+            value: { latitude: 0, longitude: -179.9 },
+            timestamp: iso()
+          },
+          courseOverGroundTrue: { value: 0, timestamp: iso() },
+          speedOverGround: { value: 0, timestamp: iso() }
+        }
+      }
+    }
+    const app = cpaApp({ vessels, handled })
+    const d = calcFactory(app, cpaPlugin({ distanceToSelf: true, range: 1852 }))
+    const out = d.calculator({ latitude: 0, longitude: 179.9 }, 0, 0)
+    out.should.deep.equal([])
+    handled.should.deep.equal([])
+  })
+
+  it('cheap-reject passes vessels across the date line that are within range', () => {
+    // Self at 179.9995, vessel at -179.9995 => actual delta 0.001deg
+    // (~111m), well inside 1852m range. The wrap-aware cheap reject must
+    // NOT drop this vessel.
+    const handled = []
+    const vessels = {
+      other: {
+        navigation: {
+          position: {
+            value: { latitude: 0, longitude: -179.9995 },
+            timestamp: iso()
+          },
+          courseOverGroundTrue: { value: 0, timestamp: iso() },
+          speedOverGround: { value: 0, timestamp: iso() }
+        }
+      }
+    }
+    const app = cpaApp({ vessels, handled })
+    const d = calcFactory(app, cpaPlugin({ distanceToSelf: true, range: 1852 }))
+    d.calculator({ latitude: 0, longitude: 179.9995 }, 0, 0)
+    const dist = handled.find(
+      (x) => x.updates[0].values[0].path === 'navigation.distanceToSelf'
+    )
+    expect(dist).to.exist
+  })
+
   it('cheap-reject is disabled when range < 0 and falls through to geolib', () => {
     const handled = []
     const vessels = {

--- a/test/cpa_tcpa.js
+++ b/test/cpa_tcpa.js
@@ -100,6 +100,62 @@ describe('cpa_tcpa', () => {
     out.should.deep.equal([])
   })
 
+  it('cheap-reject skips distanceToSelf emission for far vessels when range>=0', () => {
+    // When a positive range is configured, a vessel whose coarse lat/lon
+    // delta already exceeds the range is filtered before the geolib call,
+    // which also suppresses the per-tick distanceToSelf emission. Users who
+    // want distances for arbitrarily-far vessels should set range < 0.
+    const handled = []
+    const vessels = {
+      other: {
+        navigation: {
+          position: {
+            value: { latitude: 10, longitude: 10 }, // ~1500km away
+            timestamp: iso()
+          },
+          courseOverGroundTrue: { value: 0, timestamp: iso() },
+          speedOverGround: { value: 0, timestamp: iso() }
+        }
+      }
+    }
+    const app = cpaApp({ vessels, handled })
+    const d = calcFactory(
+      app,
+      cpaPlugin({ distanceToSelf: true, range: 1852 })
+    )
+    const out = d.calculator({ latitude: 0, longitude: 0 }, 0, 0)
+    out.should.deep.equal([])
+    handled.should.deep.equal([])
+  })
+
+  it('cheap-reject is disabled when range < 0 and falls through to geolib', () => {
+    const handled = []
+    const vessels = {
+      other: {
+        navigation: {
+          position: {
+            value: { latitude: 1, longitude: 0 }, // ~111 km away
+            timestamp: iso()
+          },
+          courseOverGroundTrue: { value: 0, timestamp: iso() },
+          speedOverGround: { value: 0, timestamp: iso() }
+        }
+      }
+    }
+    const app = cpaApp({ vessels, handled })
+    const d = calcFactory(
+      app,
+      cpaPlugin({ distanceToSelf: true, range: -1 })
+    )
+    d.calculator({ latitude: 0, longitude: 0 }, 0, 0)
+    // With range disabled, we still compute distance and emit distanceToSelf.
+    const dist = handled.find(
+      (x) => x.updates[0].values[0].path === 'navigation.distanceToSelf'
+    )
+    expect(dist).to.exist
+    expect(dist.updates[0].values[0].value).to.be.greaterThan(100000)
+  })
+
   it('emits null distanceToSelf + null CPA when the position timestamp is stale', () => {
     const vessels = {
       other: {

--- a/test/cpa_tcpa.js
+++ b/test/cpa_tcpa.js
@@ -119,13 +119,73 @@ describe('cpa_tcpa', () => {
       }
     }
     const app = cpaApp({ vessels, handled })
-    const d = calcFactory(
-      app,
-      cpaPlugin({ distanceToSelf: true, range: 1852 })
-    )
+    const d = calcFactory(app, cpaPlugin({ distanceToSelf: true, range: 1852 }))
     const out = d.calculator({ latitude: 0, longitude: 0 }, 0, 0)
     out.should.deep.equal([])
     handled.should.deep.equal([])
+  })
+
+  it('distanceToSelf is skipped on subsequent calls when the distance barely changes', () => {
+    const handled = []
+    const vessels = {
+      other: {
+        navigation: {
+          position: {
+            value: { latitude: 0.01, longitude: 0 },
+            timestamp: iso()
+          },
+          courseOverGroundTrue: { value: 0, timestamp: iso() },
+          speedOverGround: { value: 0, timestamp: iso() }
+        }
+      }
+    }
+    const app = cpaApp({ vessels, handled })
+    const d = calcFactory(app, cpaPlugin({ distanceToSelf: true, range: -1 }))
+    d.calculator({ latitude: 0, longitude: 0 }, 0, 0)
+    handled
+      .filter(
+        (x) => x.updates[0].values[0].path === 'navigation.distanceToSelf'
+      )
+      .should.have.length(1)
+    // Second call at the exact same position: distance has not changed so
+    // no new delta should be emitted.
+    d.calculator({ latitude: 0, longitude: 0 }, 0, 0)
+    handled
+      .filter(
+        (x) => x.updates[0].values[0].path === 'navigation.distanceToSelf'
+      )
+      .should.have.length(1)
+  })
+
+  it('distanceToSelf re-emits once the accumulated change crosses the threshold', () => {
+    const handled = []
+    const vessels = {
+      other: {
+        navigation: {
+          position: {
+            value: { latitude: 0.01, longitude: 0 },
+            timestamp: iso()
+          },
+          courseOverGroundTrue: { value: 0, timestamp: iso() },
+          speedOverGround: { value: 0, timestamp: iso() }
+        }
+      }
+    }
+    const app = cpaApp({ vessels, handled })
+    const d = calcFactory(app, cpaPlugin({ distanceToSelf: true, range: -1 }))
+    d.calculator({ latitude: 0, longitude: 0 }, 0, 0)
+    // Move self position enough to yield >1m change in computed distance.
+    vessels.other.navigation.position.value = {
+      latitude: 0.0105,
+      longitude: 0
+    }
+    vessels.other.navigation.position.timestamp = iso()
+    d.calculator({ latitude: 0, longitude: 0 }, 0, 0)
+    handled
+      .filter(
+        (x) => x.updates[0].values[0].path === 'navigation.distanceToSelf'
+      )
+      .should.have.length(2)
   })
 
   it('cheap-reject is disabled when range < 0 and falls through to geolib', () => {
@@ -143,10 +203,7 @@ describe('cpa_tcpa', () => {
       }
     }
     const app = cpaApp({ vessels, handled })
-    const d = calcFactory(
-      app,
-      cpaPlugin({ distanceToSelf: true, range: -1 })
-    )
+    const d = calcFactory(app, cpaPlugin({ distanceToSelf: true, range: -1 }))
     d.calculator({ latitude: 0, longitude: 0 }, 0, 0)
     // With range disabled, we still compute distance and emit distanceToSelf.
     const dist = handled.find(


### PR DESCRIPTION
## Summary

Addresses task 3 of #180. Five focused optimizations to `calcs/cpa_tcpa.js`, the per-tick loop that scales with AIS target count.

- **Hoist `vesselList[id]`** — one `app.getPath('vessels')` per tick, then direct `vesselList[id].navigation.position.value`-style access. Replaces the previous `N×` `app.getPath('vessels.' + id + '.<path>')` string walks and collapses the three `secondsSinceVesselUpdate` calls into a single inlined `isStale(currentMs, ts, limit)` that pulls `currentMs` once per tick.
- **Reuse scratch `otherVessel`** — one `{ location: {}, speed, heading }` allocation outside the loop, mutated per vessel. `geoutils.cpa` treats its inputs as read-only so the reuse is safe.
- **Inline notification-zone loop** — `notificationZones.filter(...).forEach(...)` replaced with a plain `for` loop. Drops the intermediate array allocation and both closures.
- **Cheap lat/lon early reject** — when a positive `range` is configured, reject any vessel whose coarse `max(|dLat|·M, |dLon|·M·cos(lat))` already exceeds `range` before calling `geolib.getDistance`. `M = 111319` is metres per degree of latitude, which gives a strict lower bound on the great-circle distance. Longitude is wrapped at the ±180° meridian so date-line neighbours aren't falsely rejected.
- **Emit `distanceToSelf` only on meaningful change** — per-vessel cache of the last emitted distance, re-emit only when the delta is ≥ 1m. Moored/idle AIS targets stop producing a per-tick delta.

Also moved `alarmSent` and the new `lastDistanceToSelf` cache from module scope to the calculator closure, so plugin stop/start cycles (and tests sharing the same `require`) get fresh state instead of leaking alarm state between instances.

## Behaviour notes

- The cheap reject suppresses the per-tick `distanceToSelf` emission for clearly-out-of-range AIS targets. Users who want distance-to-self emitted for every vessel regardless of range can set `range < 0`, which disables the filter entirely and restores the old full-fat path.
- The stale-check reads on `navigation.courseOverGroundTrue` / `navigation.speedOverGround` still target the parent node (not `.timestamp`) to preserve pre-refactor behaviour — the companion correctness fix is tracked in #223 so it doesn't bundle with this perf change.

## Tests

6 new tests (251 total, up from 245):

- `cheap-reject skips distanceToSelf emission for far vessels when range>=0`
- `distanceToSelf is skipped on subsequent calls when the distance barely changes`
- `distanceToSelf re-emits once the accumulated change crosses the threshold`
- `cheap-reject handles longitude wraparound across the ±180 meridian`
- `cheap-reject passes vessels across the date line that are within range`
- `cheap-reject is disabled when range < 0 and falls through to geolib`

All 251 tests pass; `npm run prettier:check` is clean.

Refs #180