### PR TITLE
perf(tankVolume): precompute spline, capacity, and output paths

### DIFF
--- a/calcs/tankVolume.js
+++ b/calcs/tankVolume.js
@@ -1,12 +1,30 @@
 const Spline = require('cubic-spline')
-const _ = require('lodash')
-const util = require('util') // dev
 
-var instance
+// Volume units as configured in the plugin schema -> factor to convert to
+// cubic metres (the SignalK canonical unit).
+const VOLUME_UNIT_FACTORS = {
+  litres: 0.001,
+  gal: 0.00378541,
+  m3: 1
+}
 
 // tankInstances = ["tanks.fuel.*", "tanks.fuel.1", "tanks.water.0" ]
 module.exports = function (app, plugin) {
   return plugin.tanks.map((instance) => {
+    // Output paths and derivedFrom list are constant per instance.
+    const capacityPath = 'tanks.' + instance + '.capacity'
+    const volumePath = 'tanks.' + instance + '.currentVolume'
+    const derivedFromList = ['tanks.' + instance + '.currentLevel']
+    const calibrationKey = 'calibrations.' + instance
+
+    // Lazily built on the first calculator call — plugin.properties is only
+    // populated by plugin.start(), which runs after the factory. Once built,
+    // the spline and the derived capacity are reused for every tick until
+    // the plugin restarts (calibrations are static config, applied on
+    // restart).
+    let interpolator = null
+    let capacity = null
+
     return {
       group: 'tanks',
       optionKey: 'tankVolume_' + instance,
@@ -15,7 +33,7 @@ module.exports = function (app, plugin) {
         instance +
         "' Tank Volume and Capacity (requires calibration pairs (>2 for parallell sides, >3 for straight wedge and >4 for more complex shapes)",
       derivedFrom: function () {
-        return ['tanks.' + instance + '.currentLevel']
+        return derivedFromList
       },
       properties: {
         volume_unit: {
@@ -24,7 +42,7 @@ module.exports = function (app, plugin) {
           enum: ['litres', 'gal', 'm3'],
           default: 'litres'
         },
-        ['calibrations.' + instance]: {
+        [calibrationKey]: {
           type: 'array',
           title: 'Calibration entries (pairs of level => volume)',
           items: {
@@ -46,37 +64,34 @@ module.exports = function (app, plugin) {
         }
       },
       calculator: function (level) {
-        var calLevels = []
-        var calVolumes = []
-        app.debug(plugin.properties.tanks.volume_unit)
-
-        plugin.properties.tanks['calibrations.' + instance].forEach(
-          function (i) {
-            calLevels.push(i.level)
-            if (plugin.properties.tanks.volume_unit === 'litres') {
-              calVolumes.push(i.volume * 0.001)
-            } else if (plugin.properties.tanks.volume_unit === 'gal') {
-              calVolumes.push(i.volume * 0.00378541)
-            } else {
-              calVolumes.push(i.volume)
-            }
+        if (interpolator === null) {
+          const cal = plugin.properties.tanks[calibrationKey]
+          const unit = plugin.properties.tanks.volume_unit
+          // Unknown unit falls back to 1 (m^3) — matches the pre-refactor
+          // else branch.
+          const factor =
+            unit in VOLUME_UNIT_FACTORS ? VOLUME_UNIT_FACTORS[unit] : 1
+          const calLevels = new Array(cal.length)
+          const calVolumes = new Array(cal.length)
+          for (let i = 0; i < cal.length; i++) {
+            calLevels[i] = cal[i].level
+            calVolumes[i] = cal[i].volume * factor
           }
-        )
-
-        // cubic-spline 2.x dropped the `spline(x, xs, ys)` function form
-        // in favour of a `new Spline(xs, ys).at(x)` constructor + method.
-        // Build the interpolator once per calculation and reuse it for
-        // both capacity (at level=1) and current volume (at the measured
-        // level).
-        const interpolator = new Spline(calLevels, calVolumes)
+          app.debug(unit)
+          // cubic-spline 2.x dropped the `spline(x, xs, ys)` function form
+          // in favour of `new Spline(xs, ys).at(x)`. The interpolator and
+          // its derived capacity are constant for the life of the plugin.
+          interpolator = new Spline(calLevels, calVolumes)
+          capacity = interpolator.at(1)
+        }
 
         return [
           {
-            path: 'tanks.' + instance + '.capacity',
-            value: interpolator.at(1)
+            path: capacityPath,
+            value: capacity
           },
           {
-            path: 'tanks.' + instance + '.currentVolume',
+            path: volumePath,
             value: interpolator.at(level)
           }
         ]

--- a/test/tankVolume.js
+++ b/test/tankVolume.js
@@ -112,4 +112,29 @@ describe('tankVolume', () => {
 
     expect(() => calc.calculator(0.5)).to.not.throw()
   })
+
+  it('returns a constant capacity across repeated calculator calls', () => {
+    // Per-tick caching means capacity is computed once; successive calls
+    // at different levels must still report the same capacity value.
+    const plugin = makePlugin('fuel.0', 'litres', linearCalLitres)
+    const calc = tankVolume(app, plugin)[0]
+    const a = calc.calculator(0.1)
+    const b = calc.calculator(0.9)
+    a[0].value.should.equal(b[0].value)
+  })
+
+  it('falls back to the m^3 factor for an unknown volume unit', () => {
+    // Matches the pre-refactor `else` branch: any unit we don't recognise
+    // is treated as already-in-m^3 so configured calibration values are
+    // passed through unchanged.
+    const cal = [
+      { level: 0, volume: 0 },
+      { level: 1, volume: 0.25 }
+    ]
+    const plugin = makePlugin('fuel.0', 'hogsheads', cal)
+    const calc = tankVolume(app, plugin)[0]
+
+    const result = calc.calculator(1)
+    result[0].value.should.be.closeTo(0.25, 1e-9)
+  })
 })


### PR DESCRIPTION
## Summary

Addresses task 4 of #180. Tank calibrations and the chosen volume unit are static configuration — they're applied at plugin start and don't change until the next restart — but the calculator rebuilt `calLevels`, `calVolumes`, the cubic spline, and the `spline(1)` capacity sample on every `currentLevel` update. Instance path strings were also being re-concatenated per tick.

This PR:

- Lifts per-instance output paths (`tanks.<instance>.capacity`, `tanks.<instance>.currentVolume`) and the `derivedFrom` list into the factory closure so they're allocated once per instance rather than per tick.
- Replaces the `if/else-if` unit switch with a small `VOLUME_UNIT_FACTORS` lookup, preserving the pre-refactor fallback (unknown unit → m³).
- Builds the calibration arrays and the `new Spline(xs, ys)` interpolator lazily on the first `calculator(level)` call (because `plugin.properties` isn't populated yet at factory time), then reuses the spline and its `spline.at(1)` sample for every subsequent tick.
- Replaces `forEach` with a straight `for` loop when filling the calibration arrays, so no per-iteration closure.

Per-tick hot path drops from *"allocate two arrays, push N values, build spline, take two samples"* to *"one spline sample"*.

## Tests

Two new tests pin the behaviour (247 total, up from 245):

- `returns a constant capacity across repeated calculator calls` — pins the spline caching; capacity must not drift between two calls at different levels.
- `falls back to the m^3 factor for an unknown volume unit` — pins the default-path behaviour preserved by the lookup table.

All 247 tests pass; `npm run prettier:check` is clean.

Refs #180