### PR TITLE
perf(calcs): precompute instance paths and derivedFrom lists

### DIFF
--- a/calcs/batteryPower.js
+++ b/calcs/batteryPower.js
@@ -1,21 +1,19 @@
-const _ = require('lodash')
-
 module.exports = function (app, plugin) {
   return plugin.batteries.map((instance) => {
+    const powerPath = 'electrical.batteries.' + instance + '.power'
+    const derivedFromList = [
+      'electrical.batteries.' + instance + '.voltage',
+      'electrical.batteries.' + instance + '.current'
+    ]
     return {
       group: 'electrical',
       optionKey: 'batterPower' + instance,
       title: 'Battery ' + instance + ' Power ',
       derivedFrom: function () {
-        return [
-          'electrical.batteries.' + instance + '.voltage',
-          'electrical.batteries.' + instance + '.current'
-        ]
+        return derivedFromList
       },
       calculator: function (v, a) {
-        return [
-          { path: 'electrical.batteries.' + instance + '.power', value: v * a }
-        ]
+        return [{ path: powerPath, value: v * a }]
       }
     }
   })

--- a/calcs/dewPoint.js
+++ b/calcs/dewPoint.js
@@ -1,18 +1,20 @@
 const _ = require('lodash')
 
-selfData = {}
+const selfData = {}
 
 module.exports = function (app, plugin) {
   return plugin.air.map((instance) => {
+    const dewPointPath = 'environment.' + instance + '.dewPointTemperature'
+    const derivedFromList = [
+      'environment.' + instance + '.temperature',
+      'environment.' + instance + '.humidity'
+    ]
     return {
       group: 'air',
       optionKey: instance + 'dewPoint',
       title: instance + 'Air dewpoint temperature',
       derivedFrom: function () {
-        return [
-          'environment.' + instance + '.temperature',
-          'environment.' + instance + '.humidity'
-        ]
+        return derivedFromList
       },
       calculator: function (temp, hum) {
         let dewPoint = null
@@ -26,7 +28,7 @@ module.exports = function (app, plugin) {
         }
         return [
           {
-            path: 'environment.' + instance + '.dewPointTemperature',
+            path: dewPointPath,
             value: dewPoint
           }
         ]

--- a/calcs/fuelConsumtion.js
+++ b/calcs/fuelConsumtion.js
@@ -1,28 +1,23 @@
-const _ = require('lodash')
-
 module.exports = function (app, plugin) {
-  var engines = plugin.engines
+  const engines = plugin.engines
 
   app.debug('engines: %j', engines)
 
   return engines.map((instance) => {
+    const economyPath = 'propulsion.' + instance + '.fuel.economy'
+    const derivedFromList = [
+      'propulsion.' + instance + '.fuel.rate',
+      'navigation.speedOverGround'
+    ]
     return {
       group: 'propulsion',
       optionKey: 'economy' + instance,
       title: `${instance} fuel economy`,
       derivedFrom: function () {
-        return [
-          'propulsion.' + instance + '.fuel.rate',
-          'navigation.speedOverGround'
-        ]
+        return derivedFromList
       },
       calculator: function (rate, speed) {
-        return [
-          {
-            path: 'propulsion.' + instance + '.fuel.economy',
-            value: speed / rate
-          }
-        ]
+        return [{ path: economyPath, value: speed / rate }]
       }
     }
   })

--- a/calcs/propState.js
+++ b/calcs/propState.js
@@ -1,33 +1,33 @@
-const _ = require('lodash')
-
 module.exports = function (app, plugin) {
-  var engines = plugin.engines
+  const engines = plugin.engines
 
   app.debug('engines: %j', engines)
 
   return engines.map((instance) => {
+    const statePath = 'propulsion.' + instance + '.state'
+    const currentStatePath = 'propulsion.' + instance + '.state.value'
+    const derivedFromList = ['propulsion.' + instance + '.revolutions']
     return {
       group: 'propulsion',
       optionKey: instance + 'state',
       title: `${instance} propulsion state (based on revolutions)`,
       derivedFrom: function () {
-        return ['propulsion.' + instance + '.revolutions']
+        return derivedFromList
       },
       calculator: function (revol) {
-        const currentState =
-          app.getSelfPath('propulsion.' + instance + '.state.value') || 'none'
+        const currentState = app.getSelfPath(currentStatePath) || 'none'
 
         if (revol > 0 && currentState !== 'started') {
           return [
             {
-              path: 'propulsion.' + instance + '.state',
+              path: statePath,
               value: 'started'
             }
           ]
         } else if (!revol && currentState !== 'stopped') {
           return [
             {
-              path: 'propulsion.' + instance + '.state',
+              path: statePath,
               value: 'stopped'
             }
           ]

--- a/calcs/propslip.js
+++ b/calcs/propslip.js
@@ -1,5 +1,3 @@
-const _ = require('lodash')
-
 const selfData = {
   propulsion: {
     port: {
@@ -21,6 +19,14 @@ const selfData = {
 
 module.exports = function (app, plugin) {
   return plugin.engines.map((instance) => {
+    const slipPath = 'propulsion.' + instance + '.drive.propeller.slip'
+    const gearRatioPath =
+      'propulsion.' + instance + '.transmission.gearRatio.value'
+    const pitchPath = 'propulsion.' + instance + '.drive.propeller.pitch.value'
+    const derivedFromList = [
+      'propulsion.' + instance + '.revolutions',
+      'navigation.speedThroughWater'
+    ]
     return {
       group: 'propulsion',
       optionKey: 'propslip' + instance,
@@ -33,22 +39,15 @@ module.exports = function (app, plugin) {
         instance +
         '.drive.propeller.pitch)',
       derivedFrom: function () {
-        return [
-          'propulsion.' + instance + '.revolutions',
-          'navigation.speedThroughWater'
-        ]
+        return derivedFromList
       },
       calculator: function (revolutions, stw) {
-        var gearRatio = app.getSelfPath(
-          'propulsion.' + instance + '.transmission.gearRatio.value'
-        )
-        var pitch = app.getSelfPath(
-          'propulsion.' + instance + '.drive.propeller.pitch.value'
-        )
+        const gearRatio = app.getSelfPath(gearRatioPath)
+        const pitch = app.getSelfPath(pitchPath)
         if (revolutions > 0) {
           return [
             {
-              path: 'propulsion.' + instance + '.drive.propeller.slip',
+              path: slipPath,
               value: 1 - (stw * gearRatio) / (revolutions * pitch)
             }
           ]

--- a/calcs/tankVolume2.js
+++ b/calcs/tankVolume2.js
@@ -1,7 +1,10 @@
-const _ = require('lodash')
-
 module.exports = function (app, plugin) {
   return plugin.tanks.map((instance) => {
+    const volumePath = 'tanks.' + instance + '.currentVolume'
+    const derivedFromList = [
+      'tanks.' + instance + '.currentLevel',
+      'tanks.' + instance + '.capacity'
+    ]
     return {
       group: 'tanks',
       optionKey: 'tankVolume2_' + instance,
@@ -10,15 +13,12 @@ module.exports = function (app, plugin) {
         instance +
         ' Volume (alternate currentVolume calculation than one above, select only one calculation per tank.) Uses ',
       derivedFrom: function () {
-        return [
-          'tanks.' + instance + '.currentLevel',
-          'tanks.' + instance + '.capacity'
-        ]
+        return derivedFromList
       },
       calculator: function (level, capacity) {
         return [
           {
-            path: 'tanks.' + instance + '.currentVolume',
+            path: volumePath,
             value: level * capacity
           }
         ]


### PR DESCRIPTION
## Summary

Addresses task 5 of #180. The per-instance `.map(instance => ...)` wrapper in these six calcs was re-concatenating output path strings and rebuilding a `derivedFrom` array on every tick. Both are static for the life of an instance, so they belong in the factory closure.

Affected calcs:

- `batteryPower.js`
- `dewPoint.js`
- `fuelConsumtion.js`
- `propState.js`
- `propslip.js`
- `tankVolume2.js`

Each instance now allocates its output path string(s) and its `derivedFrom` list once, regardless of how many events it processes. `derivedFrom` still exposes the `function () { return list }` shape so callers that invoke it as a function (tests and the schema builder) keep working — the list itself is the same cached reference across calls.

Also drops a few unused `const _ = require('lodash')` imports that were left behind.

## Tests

All 255 existing tests pass; `npm run prettier:check` is clean. No new tests needed: this PR is a pure refactor that preserves observable outputs (the same `{ path, value }` deltas for the same inputs), and the existing per-calc tests assert that output.

Refs #180