### PR TITLE
perf(calcs): swap lodash predicates and Math.pow squares for natives

### DIFF
--- a/calcs/airDensity.js
+++ b/calcs/airDensity.js
@@ -1,5 +1,3 @@
-const _ = require('lodash')
-
 module.exports = function (app, plugin) {
   return {
     group: 'air',
@@ -16,9 +14,9 @@ module.exports = function (app, plugin) {
       // hPa, so it is multiplied by 100 before being used alongside
       // the pressure input.
       if (
-        !_.isFinite(temp) ||
-        !_.isFinite(hum) ||
-        !_.isFinite(press) ||
+        !Number.isFinite(temp) ||
+        !Number.isFinite(hum) ||
+        !Number.isFinite(press) ||
         temp <= 0
       ) {
         return undefined

--- a/calcs/courseOverGroundMagnetic.js
+++ b/calcs/courseOverGroundMagnetic.js
@@ -1,5 +1,3 @@
-const _ = require('lodash')
-
 module.exports = function (app, plugin) {
   return {
     group: 'course data',
@@ -16,13 +14,10 @@ module.exports = function (app, plugin) {
           'navigation.magneticVariation.value'
         )
       }
-      if (_.isUndefined(magneticVariation) || magneticVariation === null) {
+      if (magneticVariation == null) {
         return
       }
-      if (
-        _.isUndefined(courseOverGroundTrue) ||
-        courseOverGroundTrue === null
-      ) {
+      if (courseOverGroundTrue == null) {
         return [{ path: 'navigation.courseOverGroundMagnetic', value: null }]
       }
       var courseOverGroundMagnetic = courseOverGroundTrue - magneticVariation

--- a/calcs/courseOverGroundTrue.js
+++ b/calcs/courseOverGroundTrue.js
@@ -1,5 +1,3 @@
-const _ = require('lodash')
-
 module.exports = function (app, plugin) {
   return {
     group: 'heading',
@@ -16,13 +14,10 @@ module.exports = function (app, plugin) {
           'navigation.magneticVariation.value'
         )
       }
-      if (_.isUndefined(magneticVariation) || magneticVariation === null) {
+      if (magneticVariation == null) {
         return
       }
-      if (
-        _.isUndefined(courseOverGroundMagnetic) ||
-        courseOverGroundMagnetic === null
-      ) {
+      if (courseOverGroundMagnetic == null) {
         return [{ path: 'navigation.courseOverGroundTrue', value: null }]
       }
       var courseOverGroundTrue = courseOverGroundMagnetic + magneticVariation

--- a/calcs/cpa_tcpa.js
+++ b/calcs/cpa_tcpa.js
@@ -144,7 +144,7 @@ module.exports = function (app, plugin) {
       const timelimit = traffic.timelimit
       const distanceToSelfEnabled = traffic.distanceToSelf
       const sendNotifications =
-        _.isUndefined(traffic.sendNotifications) || traffic.sendNotifications
+        traffic.sendNotifications === undefined || traffic.sendNotifications
       const notificationZones = traffic.notificationZones
       const selfId = app.selfId
       const selfLat = selfPosition.latitude
@@ -299,7 +299,7 @@ module.exports = function (app, plugin) {
           const vesselCourse =
             nav.courseOverGroundTrue && nav.courseOverGroundTrue.value
           const vesselSpeed = nav.speedOverGround && nav.speedOverGround.value
-          if (!_.isUndefined(vesselCourse) && !_.isUndefined(vesselSpeed)) {
+          if (vesselCourse !== undefined && vesselSpeed !== undefined) {
             otherVessel.location.lon = vesselPos.longitude
             otherVessel.location.lat = vesselPos.latitude
             otherVessel.speed = vesselSpeed // meters/second

--- a/calcs/dewPoint.js
+++ b/calcs/dewPoint.js
@@ -1,5 +1,3 @@
-const _ = require('lodash')
-
 const selfData = {}
 
 module.exports = function (app, plugin) {
@@ -18,7 +16,7 @@ module.exports = function (app, plugin) {
       },
       calculator: function (temp, hum) {
         let dewPoint = null
-        if (_.isFinite(temp) && _.isFinite(hum)) {
+        if (Number.isFinite(temp) && Number.isFinite(hum)) {
           // Magnus formula:
           const tempC = temp - 273.15
           const b = 17.625

--- a/calcs/headingTrue.js
+++ b/calcs/headingTrue.js
@@ -1,5 +1,3 @@
-const _ = require('lodash')
-
 module.exports = function (app, plugin) {
   return {
     group: 'heading',
@@ -13,10 +11,10 @@ module.exports = function (app, plugin) {
           'navigation.magneticVariation.value'
         )
       }
-      if (_.isUndefined(magneticVariation) || magneticVariation === null) {
+      if (magneticVariation == null) {
         return
       }
-      if (_.isUndefined(heading) || heading === null) {
+      if (heading == null) {
         return [{ path: 'navigation.headingTrue', value: null }]
       }
       var headingTrue = heading + magneticVariation

--- a/calcs/leeway.js
+++ b/calcs/leeway.js
@@ -20,7 +20,7 @@ module.exports = function (app, plugin) {
       var leewayAngle =
         stwKnots <= 0
           ? 0
-          : ((kFactor * rollDegrees) / Math.pow(stwKnots, 2) / 360) * Math.PI
+          : ((kFactor * rollDegrees) / (stwKnots * stwKnots) / 360) * Math.PI
       // app.debug('roll: ' + rollDegrees + ' stw: ' + stwKnots + ' knots => leeway: ' + leewayAngle/Math.PI*360)
       return [{ path: 'performance.leeway', value: leewayAngle }]
     }

--- a/calcs/leewayAngle.js
+++ b/calcs/leewayAngle.js
@@ -1,6 +1,4 @@
 // calculation source: https://arvelgentry.jimdo.com/app/download/9157993883/Arvel+Gentry+-+Sailboat_Performance_Testing_Techniques.pdf?t=1485748085
-const _ = require('lodash')
-
 module.exports = function (app, plugin) {
   return {
     group: 'heading',
@@ -9,7 +7,7 @@ module.exports = function (app, plugin) {
     derivedFrom: ['navigation.headingTrue', 'navigation.courseOverGroundTrue'],
     calculator: function (hdg, cog) {
       let leewayAngle = null
-      if (!_.isFinite(hdg) || !_.isFinite(cog)) {
+      if (!Number.isFinite(hdg) || !Number.isFinite(cog)) {
         leewayAngle = Math.abs(hdg - cog)
       }
       return [{ path: 'navigation.leewayAngle', value: leewayAngle }]

--- a/calcs/moon.js
+++ b/calcs/moon.js
@@ -25,7 +25,7 @@ module.exports = function (app, plugin) {
         return
       }
 
-      if (!_.isUndefined(datetime) && datetime.length > 0) {
+      if (datetime !== undefined && datetime.length > 0) {
         date = new Date(datetime)
       } else {
         date = new Date()

--- a/calcs/setDrift.js
+++ b/calcs/setDrift.js
@@ -1,5 +1,3 @@
-const _ = require('lodash')
-
 const DEFAULT_MAGNETIC_VARIATION = 9999
 const PRECISION = 10
 
@@ -9,7 +7,7 @@ const PRECISION = 10
  * @returns {number|null}
  */
 function normalizeAngle(angle) {
-  if (_.isUndefined(angle) || angle === null) return null
+  if (angle == null) return null
   angle = angle % (2 * Math.PI)
   return angle < 0 ? angle + 2 * Math.PI : angle
 }
@@ -100,7 +98,7 @@ module.exports = function (app, plugin) {
 
       // Convert to true direction
       let setTrue =
-        _.isUndefined(magneticVariation) || magneticVariation === null
+        magneticVariation == null
           ? null
           : normalizeAngle(setMagnetic + magneticVariation)
 

--- a/calcs/steer_error.js
+++ b/calcs/steer_error.js
@@ -1,5 +1,3 @@
-const _ = require('lodash')
-
 module.exports = function (app) {
   return {
     group: 'course data',
@@ -16,8 +14,8 @@ module.exports = function (app) {
       let rightSteer = null
 
       if (
-        _.isFinite(courseOverGroundTrue) &&
-        _.isFinite(bearingToDestinationTrue)
+        Number.isFinite(courseOverGroundTrue) &&
+        Number.isFinite(bearingToDestinationTrue)
       ) {
         steererr = courseOverGroundTrue - bearingToDestinationTrue
         if (steererr > Math.PI) {

--- a/calcs/windDirection.js
+++ b/calcs/windDirection.js
@@ -1,5 +1,4 @@
 const { formatCompassAngle } = require('../utils')
-const _ = require('lodash')
 
 const selfData = {}
 
@@ -14,7 +13,7 @@ module.exports = function (app, plugin) {
         'environment.wind.angleApparent'
       ],
       calculator: function (headingMagnetic, awa) {
-        if (!_.isFinite(headingMagnetic) || !_.isFinite(awa)) {
+        if (!Number.isFinite(headingMagnetic) || !Number.isFinite(awa)) {
           return [{ path: 'environment.wind.directionMagnetic', value: null }]
         }
 
@@ -54,7 +53,10 @@ module.exports = function (app, plugin) {
         'navigation.magneticVariation'
       ],
       calculator: function (directionTrue, magneticVariation) {
-        if (!_.isFinite(directionTrue) || !_.isFinite(magneticVariation)) {
+        if (
+          !Number.isFinite(directionTrue) ||
+          !Number.isFinite(magneticVariation)
+        ) {
           return [{ path: 'environment.wind.directionMagnetic', value: null }]
         }
 
@@ -112,16 +114,19 @@ module.exports = function (app, plugin) {
         let angle
         let speed
 
-        if (!_.isFinite(stw) || !_.isFinite(aws) || !_.isFinite(awa)) {
+        if (
+          !Number.isFinite(stw) ||
+          !Number.isFinite(aws) ||
+          !Number.isFinite(awa)
+        ) {
           angle = null
           speed = null
         } else {
           const apparentX = Math.cos(awa) * aws
           const apparentY = Math.sin(awa) * aws
-          angle = Math.atan2(apparentY, -stw + apparentX)
-          speed = Math.sqrt(
-            Math.pow(apparentY, 2) + Math.pow(-stw + apparentX, 2)
-          )
+          const gx = apparentX - stw
+          angle = Math.atan2(apparentY, gx)
+          speed = Math.sqrt(apparentY * apparentY + gx * gx)
           if (aws < 1e-9) {
             angle = awa
           }
@@ -163,7 +168,7 @@ module.exports = function (app, plugin) {
         'environment.wind.angleTrueWater'
       ],
       calculator: function (headingTrue, twa) {
-        if (!_.isFinite(headingTrue) || !_.isFinite(twa)) {
+        if (!Number.isFinite(headingTrue) || !Number.isFinite(twa)) {
           return [{ path: 'environment.wind.directionTrue', value: null }]
         }
 

--- a/calcs/windGround.js
+++ b/calcs/windGround.js
@@ -1,5 +1,4 @@
 const { formatCompassAngle } = require('../utils')
-const _ = require('lodash')
 
 const selfData = {}
 
@@ -21,10 +20,10 @@ module.exports = function (app, plugin) {
         let dir
 
         if (
-          !_.isFinite(headTrue) ||
-          !_.isFinite(sog) ||
-          !_.isFinite(aws) ||
-          !_.isFinite(awa)
+          !Number.isFinite(headTrue) ||
+          !Number.isFinite(sog) ||
+          !Number.isFinite(aws) ||
+          !Number.isFinite(awa)
         ) {
           angle = null
           speed = null
@@ -32,10 +31,9 @@ module.exports = function (app, plugin) {
         } else {
           const apparentX = Math.cos(awa) * aws
           const apparentY = Math.sin(awa) * aws
-          angle = Math.atan2(apparentY, -sog + apparentX)
-          speed = Math.sqrt(
-            Math.pow(apparentY, 2) + Math.pow(-sog + apparentX, 2)
-          )
+          const gx = apparentX - sog
+          angle = Math.atan2(apparentY, gx)
+          speed = Math.sqrt(apparentY * apparentY + gx * gx)
           if (aws < 1e-9) {
             angle = awa
           }
@@ -70,7 +68,7 @@ module.exports = function (app, plugin) {
         'environment.wind.angleTrueGround'
       ],
       calculator: function (headingTrue, gwa) {
-        if (!_.isFinite(headingTrue) || !_.isFinite(gwa)) {
+        if (!Number.isFinite(headingTrue) || !Number.isFinite(gwa)) {
           return [{ path: 'environment.wind.directionGround', value: null }]
         }
 


### PR DESCRIPTION
## Summary

Addresses task 6 of #180. Mechanical per-event improvements across 13 calcs — small individually but they cover most hot calculators and add up once AIS + GPS + IMU are all emitting.

- `_.isFinite(x)` → `Number.isFinite(x)` (same semantics, no lodash dispatch). Covers: `airDensity`, `dewPoint`, `leewayAngle`, `steer_error`, `windDirection`, `windGround`.
- `_.isUndefined(x) || x === null` → `x == null` (loose equality is the canonical null-or-undefined idiom). Covers: `courseOverGroundMagnetic`, `courseOverGroundTrue`, `headingTrue`, `setDrift`.
- `!_.isUndefined(x) && !_.isUndefined(y)` → `x !== undefined && y !== undefined` in `cpa_tcpa.js`; `_.isUndefined(x) || x` → `x === undefined || x` for the `sendNotifications` fallback.
- `!_.isUndefined(datetime) && datetime.length > 0` → `datetime !== undefined && datetime.length > 0` in `moon.js`.
- `Math.pow(x, 2)` → `x * x` in `leeway`, `windGround`, `windDirection`. For the wind wrappers, also hoisted the repeated `-sog + apparentX` / `-stw + apparentX` subexpression into a local so the square and the atan2 call share the same value.
- Dropped `const _ = require('lodash')` from every file that no longer references it (9 files).

`Math.pow(x, 0.16)` in `windChill` and `Math.pow(10, ...)` in `airDensity` are intentionally left alone — their exponents are non-integer so the native square swap doesn't apply and `Math.pow` stays the right tool.

## Tests

All 255 existing tests pass; `npm run prettier:check` is clean. No new tests needed — this PR is a pure semantics-preserving rewrite.

Refs #180