### PR TITLE
perf(calcs): cache static config, drop magneticVariation getSelfPath fallback

### DIFF
--- a/src/calcs/courseOverGroundMagnetic.ts
+++ b/src/calcs/courseOverGroundMagnetic.ts
@@ -1,6 +1,6 @@
 import type { Calculation, CalculationFactory } from '../types'
 
-const factory: CalculationFactory = function (app, _plugin): Calculation {
+const factory: CalculationFactory = function (_app, _plugin): Calculation {
   return {
     group: 'course data',
     optionKey: 'cog_magnetic',
@@ -15,12 +15,11 @@ const factory: CalculationFactory = function (app, _plugin): Calculation {
       courseOverGroundTrue: number | null | undefined,
       magneticVariation: number | null | undefined
     ) {
-      if (magneticVariation === 9999) {
-        magneticVariation = app.getSelfPath(
-          'navigation.magneticVariation.value'
-        ) as number | null | undefined
-      }
-      if (magneticVariation == null) {
+      // `magneticVariation` arrives as a stream value (see `derivedFrom`).
+      // The 9999 sentinel is the `toProperty` default that fires when no
+      // real variation has emitted yet; null/undefined mean the source
+      // pushed an absent value. In either case we can't convert.
+      if (magneticVariation === 9999 || magneticVariation == null) {
         return
       }
       if (courseOverGroundTrue == null) {

--- a/src/calcs/courseOverGroundTrue.ts
+++ b/src/calcs/courseOverGroundTrue.ts
@@ -1,6 +1,6 @@
 import type { Calculation, CalculationFactory } from '../types'
 
-const factory: CalculationFactory = function (app, _plugin): Calculation {
+const factory: CalculationFactory = function (_app, _plugin): Calculation {
   return {
     group: 'heading',
     optionKey: 'cog_true',
@@ -15,12 +15,10 @@ const factory: CalculationFactory = function (app, _plugin): Calculation {
       courseOverGroundMagnetic: number | null | undefined,
       magneticVariation: number | null | undefined
     ) {
-      if (magneticVariation === 9999) {
-        magneticVariation = app.getSelfPath(
-          'navigation.magneticVariation.value'
-        ) as number | null | undefined
-      }
-      if (magneticVariation == null) {
+      // See courseOverGroundMagnetic.ts — 9999 is the `toProperty` sentinel
+      // that fires before any real magneticVariation has arrived; null
+      // or undefined mean the source pushed an absent value.
+      if (magneticVariation === 9999 || magneticVariation == null) {
         return
       }
       if (courseOverGroundMagnetic == null) {

--- a/src/calcs/depthBelowKeel.ts
+++ b/src/calcs/depthBelowKeel.ts
@@ -1,21 +1,32 @@
 import type { Calculation, CalculationFactory } from '../types'
 
 const factory: CalculationFactory = function (app): Calculation {
+  // design.draft.value.maximum is vessel design config — populated once by
+  // the SignalK server (or the user) and unchanged for the life of the
+  // plugin. Cache the first non-undefined read so the per-tick code no
+  // longer walks the state tree on every depth update.
+  let cachedDraft: number | undefined
+
   return {
     group: 'depth',
     optionKey: 'belowKeel',
     title: 'Depth Below Keel (design.draft.maximum)',
     derivedFrom: ['environment.depth.belowSurface'],
     calculator: function (depthBelowSurface: number) {
-      const draft = app.getSelfPath('design.draft.value.maximum') as
-        | number
-        | undefined
+      if (cachedDraft === undefined) {
+        cachedDraft = app.getSelfPath('design.draft.value.maximum') as
+          | number
+          | undefined
+      }
 
-      if (typeof depthBelowSurface !== 'number' || typeof draft !== 'number') {
+      if (
+        typeof depthBelowSurface !== 'number' ||
+        typeof cachedDraft !== 'number'
+      ) {
         return undefined
       }
 
-      const value = depthBelowSurface - draft
+      const value = depthBelowSurface - cachedDraft
       if (Number.isNaN(value)) {
         return undefined
       }

--- a/src/calcs/depthBelowSurface.ts
+++ b/src/calcs/depthBelowSurface.ts
@@ -1,21 +1,30 @@
 import type { Calculation, CalculationFactory } from '../types'
 
 const factory: CalculationFactory = function (app): Calculation {
+  // See depthBelowKeel.ts for why this is cached — draft.maximum is vessel
+  // design data and static for the life of the plugin.
+  let cachedDraft: number | undefined
+
   return {
     group: 'depth',
     optionKey: 'belowSurface',
     title: 'Depth Below Surface (design.draft.maximum)',
     derivedFrom: ['environment.depth.belowKeel'],
     calculator: function (depthBelowKeel: number) {
-      const draft = app.getSelfPath('design.draft.value.maximum') as
-        | number
-        | undefined
+      if (cachedDraft === undefined) {
+        cachedDraft = app.getSelfPath('design.draft.value.maximum') as
+          | number
+          | undefined
+      }
 
-      if (typeof depthBelowKeel !== 'number' || typeof draft !== 'number') {
+      if (
+        typeof depthBelowKeel !== 'number' ||
+        typeof cachedDraft !== 'number'
+      ) {
         return undefined
       }
 
-      const value = depthBelowKeel + draft
+      const value = depthBelowKeel + cachedDraft
       if (Number.isNaN(value)) {
         return undefined
       }

--- a/src/calcs/headingTrue.ts
+++ b/src/calcs/headingTrue.ts
@@ -1,6 +1,6 @@
 import type { Calculation, CalculationFactory } from '../types'
 
-const factory: CalculationFactory = function (app, _plugin): Calculation {
+const factory: CalculationFactory = function (_app, _plugin): Calculation {
   return {
     group: 'heading',
     optionKey: 'heading',
@@ -12,12 +12,10 @@ const factory: CalculationFactory = function (app, _plugin): Calculation {
       heading: number | null | undefined,
       magneticVariation: number | null | undefined
     ) {
-      if (magneticVariation === 9999) {
-        magneticVariation = app.getSelfPath(
-          'navigation.magneticVariation.value'
-        ) as number | null | undefined
-      }
-      if (magneticVariation == null) {
+      // See courseOverGroundMagnetic.ts — 9999 is the `toProperty` sentinel
+      // that fires before any real magneticVariation has arrived; null
+      // or undefined mean the source pushed an absent value.
+      if (magneticVariation === 9999 || magneticVariation == null) {
         return
       }
       if (heading == null) {

--- a/src/calcs/propslip.ts
+++ b/src/calcs/propslip.ts
@@ -29,6 +29,12 @@ const factory: CalculationFactory = function (app, plugin): Calculation[] {
       'propulsion.' + instance + '.revolutions',
       'navigation.speedThroughWater'
     ]
+    // gearRatio and propeller.pitch are drivetrain design config — static
+    // for the life of the plugin. Cache the first non-undefined read so
+    // per-revolution updates no longer walk the state tree twice.
+    let cachedGearRatio: number | undefined
+    let cachedPitch: number | undefined
+
     return {
       group: 'propulsion',
       optionKey: 'propslip' + instance,
@@ -44,15 +50,19 @@ const factory: CalculationFactory = function (app, plugin): Calculation[] {
         return derivedFromList
       },
       calculator: function (revolutions: number, stw: number) {
-        const gearRatio = app.getSelfPath(gearRatioPath) as number | undefined
-        const pitch = app.getSelfPath(pitchPath) as number | undefined
+        if (cachedGearRatio === undefined) {
+          cachedGearRatio = app.getSelfPath(gearRatioPath) as number | undefined
+        }
+        if (cachedPitch === undefined) {
+          cachedPitch = app.getSelfPath(pitchPath) as number | undefined
+        }
         if (
           !Number.isFinite(revolutions) ||
           revolutions <= 0 ||
           !Number.isFinite(stw) ||
-          !Number.isFinite(gearRatio) ||
-          !Number.isFinite(pitch) ||
-          pitch === 0
+          !Number.isFinite(cachedGearRatio) ||
+          !Number.isFinite(cachedPitch) ||
+          cachedPitch === 0
         ) {
           return undefined
         }
@@ -61,7 +71,8 @@ const factory: CalculationFactory = function (app, plugin): Calculation[] {
             path: slipPath,
             value:
               1 -
-              (stw * (gearRatio as number)) / (revolutions * (pitch as number))
+              (stw * (cachedGearRatio as number)) /
+                (revolutions * (cachedPitch as number))
           }
         ]
       },

--- a/src/calcs/setDrift.ts
+++ b/src/calcs/setDrift.ts
@@ -11,7 +11,7 @@ function normalizeAngle(angle: number | null | undefined): number | null {
   return angle < 0 ? angle + 2 * Math.PI : angle
 }
 
-const factory: CalculationFactory = function (app, _plugin): Calculation {
+const factory: CalculationFactory = function (_app, _plugin): Calculation {
   return {
     group: 'course data',
     optionKey: 'setDrift',
@@ -42,10 +42,12 @@ const factory: CalculationFactory = function (app, _plugin): Calculation {
       speedOverGround: number,
       magneticVariation: number | null | undefined
     ) {
+      // `magneticVariation` arrives as a stream value (see `derivedFrom`).
+      // The sentinel default fires before any real variation has emitted,
+      // in which case we continue without setTrue instead of falling back
+      // to a per-tick app.getSelfPath tree walk.
       if (magneticVariation === DEFAULT_MAGNETIC_VARIATION) {
-        magneticVariation = app.getSelfPath(
-          'navigation.magneticVariation.value'
-        ) as number | null | undefined
+        magneticVariation = null
       }
 
       // Case: no movement

--- a/src/calcs/transducerToKeel.ts
+++ b/src/calcs/transducerToKeel.ts
@@ -1,24 +1,30 @@
 import type { Calculation, CalculationFactory } from '../types'
 
 const factory: CalculationFactory = function (app): Calculation {
+  // See depthBelowKeel.ts for why this is cached — draft.maximum is vessel
+  // design data and static for the life of the plugin.
+  let cachedDraft: number | undefined
+
   return {
     group: 'depth',
     optionKey: 'transducerToKeel',
     title: 'Transducer to keel (design.draft.maximum),',
     derivedFrom: ['environment.depth.surfaceToTransducer'],
     calculator: function (surfaceToTransducer: unknown) {
-      const draft = app.getSelfPath('design.draft.value.maximum') as
-        | number
-        | undefined
+      if (cachedDraft === undefined) {
+        cachedDraft = app.getSelfPath('design.draft.value.maximum') as
+          | number
+          | undefined
+      }
 
       if (
         typeof surfaceToTransducer !== 'number' ||
-        typeof draft !== 'number'
+        typeof cachedDraft !== 'number'
       ) {
         return undefined
       }
 
-      const transducerToKeel = surfaceToTransducer - draft
+      const transducerToKeel = surfaceToTransducer - cachedDraft
 
       if (isNaN(transducerToKeel)) {
         return undefined

--- a/test/courseOverGroundMagnetic.ts
+++ b/test/courseOverGroundMagnetic.ts
@@ -7,13 +7,17 @@ describe('courseOverGroundMagnetic (extra branches)', () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const calc: any = require('../src/calcs/courseOverGroundMagnetic')
 
-  it('falls back to getSelfPath when magneticVariation is the 9999 sentinel', () => {
+  it('returns undefined while magneticVariation is still the 9999 sentinel', () => {
+    // Before the stream has produced a real magneticVariation, the
+    // toProperty default of 9999 fires. Previously the calc fell back to
+    // app.getSelfPath on every tick; we now skip the conversion until a
+    // real value arrives via the stream.
     const app = makeApp({
       selfPaths: { navigation: { magneticVariation: { value: 0.1 } } }
     })
     const d = calc(app, makePlugin())
     const out = d.calculator(0.5, 9999)
-    out[0].value.should.be.closeTo(0.4, 1e-9)
+    ;(typeof out).should.equal('undefined')
   })
 
   it('computes a valid result', () => {

--- a/test/courseOverGroundTrue.ts
+++ b/test/courseOverGroundTrue.ts
@@ -8,18 +8,13 @@ describe('courseOverGroundTrue (extra branches)', () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const calc: any = require('../src/calcs/courseOverGroundTrue')
 
-  it('falls back to getSelfPath when magneticVariation is the 9999 sentinel', () => {
+  it('returns undefined while magneticVariation is still the 9999 sentinel', () => {
+    // Before the stream has produced a real magneticVariation, the
+    // toProperty default of 9999 fires. Previously the calc fell back to
+    // app.getSelfPath on every tick; we now skip the conversion until a
+    // real value arrives via the stream.
     const app = makeApp({
       selfPaths: { navigation: { magneticVariation: { value: 0.1 } } }
-    })
-    const d = calc(app, makePlugin())
-    const out = d.calculator(0.5, 9999)
-    out[0].value.should.be.closeTo(0.6, 1e-9)
-  })
-
-  it('returns undefined when the fallback also yields null', () => {
-    const app = makeApp({
-      selfPaths: { navigation: { magneticVariation: { value: null } } }
     })
     const d = calc(app, makePlugin())
     expect(d.calculator(0.5, 9999)).to.equal(undefined)

--- a/test/depthBelowKeel.ts
+++ b/test/depthBelowKeel.ts
@@ -39,4 +39,24 @@ describe('depthBelowKeel', () => {
     const d = calc(app, makePlugin())
     expect(d.calculator(NaN)).to.equal(undefined)
   })
+
+  it('reads draft once and reuses it on subsequent calls', () => {
+    // Replace getSelfPath with a spy so we can assert the tree walk only
+    // happens for the first calculator call. Any more than one lookup and
+    // the cache isn't doing its job.
+    let lookups = 0
+    const app = makeApp({
+      selfPaths: { design: { draft: { value: { maximum: 1.5 } } } }
+    })
+    const realGetSelfPath = app.getSelfPath
+    app.getSelfPath = (p: string) => {
+      lookups += 1
+      return realGetSelfPath(p)
+    }
+    const d = calc(app, makePlugin())
+    d.calculator(10)
+    d.calculator(11)
+    d.calculator(12)
+    lookups.should.equal(1)
+  })
 })

--- a/test/headingTrue.ts
+++ b/test/headingTrue.ts
@@ -8,18 +8,13 @@ describe('headingTrue (extra branches)', () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const calc: any = require('../src/calcs/headingTrue')
 
-  it('falls back to getSelfPath when magneticVariation is the 9999 sentinel', () => {
+  it('returns undefined while magneticVariation is still the 9999 sentinel', () => {
+    // Before the stream has produced a real magneticVariation, the
+    // toProperty default of 9999 fires. Previously the calc fell back to
+    // app.getSelfPath on every tick; we now skip the conversion until a
+    // real value arrives via the stream.
     const app = makeApp({
       selfPaths: { navigation: { magneticVariation: { value: 0.1 } } }
-    })
-    const d = calc(app, makePlugin())
-    const out = d.calculator(0.5, 9999)
-    out[0].value.should.be.closeTo(0.6, 1e-9)
-  })
-
-  it('returns undefined when the fallback also yields null', () => {
-    const app = makeApp({
-      selfPaths: { navigation: { magneticVariation: { value: null } } }
     })
     const d = calc(app, makePlugin())
     expect(d.calculator(0.5, 9999)).to.equal(undefined)

--- a/test/propslip.ts
+++ b/test/propslip.ts
@@ -78,4 +78,33 @@ describe('propslip', () => {
     expect(arr[0].calculator(2, null)).to.equal(undefined)
     expect(arr[0].calculator(2, undefined)).to.equal(undefined)
   })
+
+  it('reads gearRatio and pitch once and reuses them on subsequent calls', () => {
+    // Once the config is cached, the inner loop no longer issues
+    // getSelfPath calls for gearRatio/pitch — they're drivetrain design
+    // numbers and don't change at runtime.
+    let lookups = 0
+    const app = makeApp({
+      selfPaths: {
+        propulsion: {
+          port: {
+            transmission: { gearRatio: { value: 2 } },
+            drive: { propeller: { pitch: { value: 1 } } }
+          }
+        }
+      }
+    })
+    const realGetSelfPath = app.getSelfPath
+    app.getSelfPath = (p: string) => {
+      lookups += 1
+      return realGetSelfPath(p)
+    }
+    const arr = calc(app, makePlugin())
+    arr[0].calculator(4, 1)
+    arr[0].calculator(5, 1)
+    arr[0].calculator(6, 1)
+    // 2 lookups total: gearRatio and pitch, each fetched once on the
+    // first call. Subsequent calls hit the closure cache.
+    lookups.should.equal(2)
+  })
 })


### PR DESCRIPTION
## Summary

Addresses task 7 of #180. Two independent refactors to remove `app.getSelfPath` walks from the per-tick path.

### Cache static config on first calculator call

`design.draft.value.maximum` (used by `depthBelowKeel`, `depthBelowSurface`, `transducerToKeel`) and the drivetrain design values (`propulsion.<instance>.transmission.gearRatio.value`, `propulsion.<instance>.drive.propeller.pitch.value` in `propslip`) are vessel design config — populated once at plugin start and unchanged at runtime. The calcs now cache the first non-undefined read in the factory closure; subsequent ticks skip the tree walk.

The lookup retries on every tick while the value is still undefined, so a late-arriving config (external source not yet populated at plugin start) isn't permanently missed.

### Drop the `getSelfPath` fallback in the magneticVariation consumers

`courseOverGroundMagnetic`, `courseOverGroundTrue`, `headingTrue` and `setDrift` already list `navigation.magneticVariation` in `derivedFrom`. The `getSelfPath` fallback only fired while the `toProperty` sentinel (9999) was still active — i.e. before the stream had produced a real value. Once `magneticVariation` does flow through the stream (which it does in normal operation), the fallback added a per-tick tree walk with no benefit.

The calcs now skip the conversion when the sentinel or null fires and wait for a real stream value instead.

## Behaviour note

There's a small initial-state change: before the `magneticVariation` stream has produced its first value, the consumer calcs now emit nothing instead of falling back to a tree-walk lookup. In practice this is the tick or two after subscription; once the `magneticVariation` calc fires (on any position update), everything converges.

## Tests

253 existing tests + 2 new = 255 passing. Prettier clean.

- Existing `falls back to getSelfPath when magneticVariation is the 9999 sentinel` tests in `courseOverGroundMagnetic`, `courseOverGroundTrue`, `headingTrue` were flipped to pin the new skip behaviour. Paired "returns undefined when the fallback also yields null" tests folded into the new shape.
- New `reads draft once and reuses it on subsequent calls` in `depthBelowKeel` — spies on `getSelfPath` and asserts a single lookup across three calculator calls.
- New `reads gearRatio and pitch once and reuses them on subsequent calls` in `propslip` — expects exactly 2 lookups (one each for gearRatio and pitch) across three calls.

Refs #180