### PR TITLE
perf(calcs): raise debounceDelay to 200 ms on wind/heading/current calcs

### DIFF
--- a/calcs/courseOverGroundMagnetic.js
+++ b/calcs/courseOverGroundMagnetic.js
@@ -10,6 +10,7 @@ module.exports = function (app, plugin) {
       'navigation.magneticVariation'
     ],
     defaults: [undefined, 9999],
+    debounceDelay: 200,
     calculator: function (courseOverGroundTrue, magneticVariation) {
       if (magneticVariation === 9999) {
         magneticVariation = app.getSelfPath(

--- a/calcs/courseOverGroundTrue.js
+++ b/calcs/courseOverGroundTrue.js
@@ -10,6 +10,7 @@ module.exports = function (app, plugin) {
       'navigation.magneticVariation'
     ],
     defaults: [undefined, 9999],
+    debounceDelay: 200,
     calculator: function (courseOverGroundMagnetic, magneticVariation) {
       if (magneticVariation === 9999) {
         magneticVariation = app.getSelfPath(

--- a/calcs/headingTrue.js
+++ b/calcs/headingTrue.js
@@ -7,6 +7,7 @@ module.exports = function (app, plugin) {
     title: 'True Heading',
     derivedFrom: ['navigation.headingMagnetic', 'navigation.magneticVariation'],
     defaults: [undefined, 9999],
+    debounceDelay: 200,
     calculator: function (heading, magneticVariation) {
       if (magneticVariation === 9999) {
         magneticVariation = app.getSelfPath(

--- a/calcs/leeway.js
+++ b/calcs/leeway.js
@@ -5,6 +5,7 @@ module.exports = function (app, plugin) {
     optionKey: 'leeway',
     title: 'Leeway',
     derivedFrom: ['navigation.attitude', 'navigation.speedThroughWater'],
+    debounceDelay: 200,
     properties: {
       kFactor: {
         type: 'number',

--- a/calcs/leewayAngle.js
+++ b/calcs/leewayAngle.js
@@ -7,6 +7,7 @@ module.exports = function (app, plugin) {
     optionKey: 'leewayAngle',
     title: 'Leeway Angle',
     derivedFrom: ['navigation.headingTrue', 'navigation.courseOverGroundTrue'],
+    debounceDelay: 200,
     calculator: function (hdg, cog) {
       let leewayAngle = null
       if (!_.isFinite(hdg) || !_.isFinite(cog)) {

--- a/calcs/setDrift.js
+++ b/calcs/setDrift.js
@@ -33,6 +33,7 @@ module.exports = function (app, plugin) {
       undefined,
       DEFAULT_MAGNETIC_VARIATION
     ],
+    debounceDelay: 200,
 
     /**
      * Calculates set and drift vector from motion data

--- a/calcs/steer_error.js
+++ b/calcs/steer_error.js
@@ -9,6 +9,7 @@ module.exports = function (app) {
       'navigation.courseOverGroundTrue',
       'navigation.course.calcValues.bearingTrue'
     ],
+    debounceDelay: 200,
     calculator: function (courseOverGroundTrue, bearingToDestinationTrue) {
       let steererr
       let steer = null

--- a/calcs/vmg_wind.js
+++ b/calcs/vmg_wind.js
@@ -7,6 +7,7 @@ module.exports = function (app) {
       'environment.wind.angleTrueWater',
       'navigation.speedOverGround'
     ],
+    debounceDelay: 200,
     calculator: function (trueWindAngle, speedOverGround) {
       var vmg_wind = Math.cos(trueWindAngle) * speedOverGround
       return [{ path: 'performance.velocityMadeGood', value: vmg_wind }]

--- a/calcs/vmg_wind_stw.js
+++ b/calcs/vmg_wind_stw.js
@@ -7,6 +7,7 @@ module.exports = function (app) {
       'environment.wind.angleTrueWater',
       'navigation.speedThroughWater'
     ],
+    debounceDelay: 200,
     calculator: function (angleTrueWater, speedThroughWater) {
       return [
         {

--- a/calcs/windChill.js
+++ b/calcs/windChill.js
@@ -7,6 +7,7 @@ module.exports = function (app, plugin) {
       'environment.outside.temperature',
       'environment.wind.speedApparent'
     ],
+    debounceDelay: 200,
     calculator: function (temp, windSpeed) {
       // standard Wind Chill formula for Environment Canada
       const tempC = temp - 273.16

--- a/calcs/windDirection.js
+++ b/calcs/windDirection.js
@@ -13,6 +13,7 @@ module.exports = function (app, plugin) {
         'navigation.headingMagnetic',
         'environment.wind.angleApparent'
       ],
+      debounceDelay: 200,
       calculator: function (headingMagnetic, awa) {
         if (!_.isFinite(headingMagnetic) || !_.isFinite(awa)) {
           return [{ path: 'environment.wind.directionMagnetic', value: null }]
@@ -53,6 +54,7 @@ module.exports = function (app, plugin) {
         'environment.wind.directionTrue',
         'navigation.magneticVariation'
       ],
+      debounceDelay: 200,
       calculator: function (directionTrue, magneticVariation) {
         if (!_.isFinite(directionTrue) || !_.isFinite(magneticVariation)) {
           return [{ path: 'environment.wind.directionMagnetic', value: null }]
@@ -108,6 +110,7 @@ module.exports = function (app, plugin) {
         'environment.wind.speedApparent',
         'environment.wind.angleApparent'
       ],
+      debounceDelay: 200,
       calculator: function (stw, aws, awa) {
         let angle
         let speed
@@ -162,6 +165,7 @@ module.exports = function (app, plugin) {
         'navigation.headingTrue',
         'environment.wind.angleTrueWater'
       ],
+      debounceDelay: 200,
       calculator: function (headingTrue, twa) {
         if (!_.isFinite(headingTrue) || !_.isFinite(twa)) {
           return [{ path: 'environment.wind.directionTrue', value: null }]

--- a/calcs/windGround.js
+++ b/calcs/windGround.js
@@ -15,6 +15,7 @@ module.exports = function (app, plugin) {
         'environment.wind.speedApparent',
         'environment.wind.angleApparent'
       ],
+      debounceDelay: 200,
       calculator: function (headTrue, sog, aws, awa) {
         let angle
         let speed
@@ -69,6 +70,7 @@ module.exports = function (app, plugin) {
         'navigation.headingTrue',
         'environment.wind.angleTrueGround'
       ],
+      debounceDelay: 200,
       calculator: function (headingTrue, gwa) {
         if (!_.isFinite(headingTrue) || !_.isFinite(gwa)) {
           return [{ path: 'environment.wind.directionGround', value: null }]

--- a/calcs/windShift.js
+++ b/calcs/windShift.js
@@ -9,6 +9,7 @@ module.exports = function (app, plugin) {
     optionKey: 'windShift',
     title: 'Wind Shift (experimental)',
     derivedFrom: ['environment.wind.angleApparent'],
+    debounceDelay: 200,
     stop: function () {
       windAvg = undefined
       if (alarmSent) {


### PR DESCRIPTION
## Summary

Addresses task 8 of #180. Calcs driven by high-rate NMEA2000 IMU and wind sources currently fire on the 20 ms default, which on a Pi with a 20 Hz attitude feed or a chatty wind transducer produces unnecessary per-emit work all the way down to `handleMessage`. Raising the debounce to 200 ms caps these at ~5 emits/s — still visually smooth for a helm display and perfectly accurate once the calcs feed into higher-level aggregates.

Calcs updated to `debounceDelay: 200`:

- `courseOverGroundMagnetic`, `courseOverGroundTrue`, `headingTrue`, `setDrift`, `leewayAngle`, `steer_error` — heading/course-driven.
- `leeway` — IMU-driven via `navigation.attitude`.
- `vmg_wind`, `vmg_wind_stw`, `windChill`, `windShift`, the four sub-calcs in `windDirection`, and the two sub-calcs in `windGround` — wind-driven.

Calcs with an existing higher debounce (`cpa_tcpa`, `magneticVariation`, `moon`, `suncalc`, `suntime`) are untouched. Depth, tank, battery, fuel, prop, dewPoint, heatIndex, airDensity and eta are driven by lower-rate sources so the default 20 ms is already fine for them.

## Tests

All 255 existing tests pass; `npm run prettier:check` is clean. No new tests needed — this PR is a configuration-only change that preserves observable semantics (same inputs → same outputs; only the emit rate is throttled).

Refs #180