### PR TITLE
docs(package): align license with LICENSE file; rewrite README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,56 +4,131 @@
 [![npm version](https://img.shields.io/npm/v/signalk-derived-data.svg)](https://www.npmjs.com/package/signalk-derived-data)
 [![License](https://img.shields.io/npm/l/signalk-derived-data.svg)](https://github.com/SignalK/signalk-derived-data/blob/master/LICENSE)
 
-Generates deltas for values derived from Signal K values
+Signal K server plugin that emits deltas for values derived from other
+Signal K values — wind angles computed from AWA + heading, CPA/TCPA
+from AIS tracks, moon illumination from time + position, tank volumes
+from calibrated levels, and so on.
 
-It currently calculates:
+## Installation
 
-- Outside air density (based on humidity, temperature and pressure)
-- Battery Power
-- Depth Below Keel (based on depth.belowSurface and design.draft.maximum)
-- Depth Below Keel (based on depth.belowTransducer and depth.transducerToKeel)
-- Depth Below Surface (based on depth.belowKeel and design.draft.maximum)
-- Distance To Go (based on courseGreatCircle.nextPoint.position)
-- Outside air dew point (based on humidity and temperature)
-- Fuel economy (based on speed over ground, fuel rate)
-- Propeller Slip calculation (requires defaults.json to include propulsion.\*.drive.propeller.pitch and propulsion.\*.transmission.gearRatio)
-- Sets environment.sun to dawn, sunrise, day, sunset, dusk or night (based on navigation.datetime or system time and navigation.position)
-- Tank Volume (based on currentLevel (requires calibration pairs (>2 for parallell sides, >3 for straight wedge and >4 for more complex shapes))
-- Velocity Made Good to Course (based on courseGreatCircle.nextPoint.bearingTrue heading true and speedOverGround)
-- Velocity Made Good to wind (based on wind.directionTrue and speedOverGround)
-- Set and Drift (based on headingMagnetic, courseOverGroundTrue, speedThroughWater, speedOverGround, magneticVariation)
-- Outside air wind chill (based on wind speed and temperature)
-- True Wind Angle, Direction and Speed (based on speed through water, AWA and AWS)
-- True Wind Direction (based on AWA and headingTrue)
-- Ground Wind Angle and Speed (based on SOG, AWA and AWS)
-- Magnetic Wind Direction (based on AWA and headingMagnetic)
-- Magnetic Wind Direction (based on wind.directionTrue and magneticVariation)
-- Wind Shift (experimental)
-- Moon illumination and times (based on time and navigation.position)
-- Sunlight Times: sunrise, sunriseEnd, goldenHourEnd, solarNoon, goldenHour, sunsetStart, sunset, dusk, nauticalDusk, night, nadir, nightEnd, nauticalDawn, dawn (based on time and navigation.position)
-- Outside Heat Index (based on temperature and humidity)
-- True Course Over Ground (based on courseOverGroundMagnetic and magneticVariation)
-- Magnetic Course Over Ground (based on courseOverGroundTrue and magneticVariation)
+Through the Signal K server admin UI — App Store → search for
+_signalk-derived-data_ → install. Or from the command line in your
+`~/.signalk` dir:
 
-To add new calculations, just create a new file under the `./calcs` directory.
-
-For example. This is the VMG calculator.
-
+```sh
+npm install signalk-derived-data
 ```
-module.exports = function(app) {
+
+Requires [signalk-server](https://github.com/SignalK/signalk-server)
+with Node `>=22`.
+
+## What it calculates
+
+Every calculator here is optional and enabled individually in the
+plugin's config screen. Each has a `derivedFrom` list of Signal K
+paths and emits on one or more output paths.
+
+### Environment
+
+- **Air density** from humidity, temperature, and pressure
+- **Air dew point** from humidity and temperature
+- **Wind chill** from wind speed and outside temperature
+- **Heat index** from outside temperature and humidity
+- **Moon illumination**, phase, rise, and set from time + position
+- **Sun mode** (`dawn` / `sunrise` / `day` / `sunset` / `dusk` /
+  `night`) from time + position
+- **Sun times** — `sunrise`, `sunriseEnd`, `goldenHourEnd`,
+  `solarNoon`, `goldenHour`, `sunsetStart`, `sunset`, `dusk`,
+  `nauticalDusk`, `night`, `nadir`, `nightEnd`, `nauticalDawn`, `dawn`
+
+### Navigation
+
+- **Distance to go** from `courseGreatCircle.nextPoint.position`
+- **Set and drift** from heading, course over ground, speed
+  through water, speed over ground, and magnetic variation
+- **True course over ground** from magnetic COG + magnetic variation
+- **Magnetic course over ground** from true COG + magnetic variation
+- **ETA** to the active waypoint
+
+### Depth
+
+- **Depth below keel** from `depth.belowSurface` + `design.draft.maximum`
+- **Depth below keel** from `depth.belowTransducer` + `depth.transducerToKeel`
+- **Depth below surface** from `depth.belowKeel` + `design.draft.maximum`
+
+### Wind
+
+- **True wind angle / direction / speed** from speed-through-water,
+  apparent wind angle, and apparent wind speed
+- **True wind direction** from AWA and true heading
+- **Ground wind angle / speed** from SOG, AWA, and AWS
+- **Magnetic wind direction** (two variants: from AWA + magnetic
+  heading, or from true wind direction + magnetic variation)
+- **Wind shift** (experimental)
+
+### Performance
+
+- **VMG to course** from the next-point true bearing, true heading,
+  and SOG
+- **VMG to wind** from true wind direction and SOG
+- **Propeller slip** (requires per-engine pitch + gear ratio in
+  `defaults.json`)
+- **Fuel economy** from SOG and fuel rate
+
+### Boat state
+
+- **Battery power** from battery voltage × current
+- **Tank volume** from current level, using calibration pairs
+  (>= 2 pairs for parallel sides, >= 3 for a wedge, >= 4 for
+  more complex shapes)
+
+### AIS
+
+- **CPA / TCPA** (closest-point-of-approach / time-to-CPA) for
+  nearby vessels, with configurable notification zones
+
+## Writing a new calculator
+
+Drop a file into `src/calcs/`. Each calculator is a default-exported
+factory function that receives the server app + plugin instance and
+returns a `Calculation` descriptor:
+
+```ts
+import type { Calculation, CalculationFactory } from '../types'
+
+const factory: CalculationFactory = function (_app): Calculation {
   return {
-    group: 'vmg',
-    optionKey: 'vmg',
-    title: "Velocity Made Goog (based on courseGreatCircle.nextPoint.bearingTrue heading true and speedOverGround)",
-    derivedFrom: [ "navigation.courseGreatCircle.nextPoint.bearingTrue",
-                   "navigation.headingTrue",
-                   "navigation.speedOverGround" ],
-    calculator: function (bearingTrue, headingTrue, speedOverGround)
-    {
-      var angle = Math.abs(bearingTrue-headingTrue)
-      return [{ path: "navigation.courseGreatCircle.nextPoint.velocityMadeGood",
-                value: Math.cos(bearingTrue-headingTrue) * speedOverGround}]
+    group: 'course data',
+    optionKey: 'vmg_Wind',
+    title: 'Velocity Made Good to wind',
+    derivedFrom: [
+      'environment.wind.angleTrueWater',
+      'navigation.speedOverGround'
+    ],
+    debounceDelay: 200,
+    calculator: function (trueWindAngle: number, speedOverGround: number) {
+      const vmg_wind = Math.cos(trueWindAngle) * speedOverGround
+      return [{ path: 'performance.velocityMadeGood', value: vmg_wind }]
     }
-  };
+  }
 }
+
+module.exports = factory
 ```
+
+`derivedFrom` lists the Signal K paths the calculator subscribes to;
+the plugin feeds their latest values into `calculator` in the same
+order. Return a `{ path, value }` list (or `[]` / `undefined` to skip
+emission this tick).
+
+## Contributing
+
+Issues and pull requests welcome at
+[SignalK/signalk-derived-data](https://github.com/SignalK/signalk-derived-data).
+`npm test` runs the full mocha suite; `npm run typecheck` +
+`npm run build` guard the TypeScript surface; `npm run mutation`
+runs Stryker against the calcs.
+
+## License
+
+Apache-2.0. See [LICENSE](LICENSE).

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
       "name": "Joachim Bakke"
     }
   ],
-  "license": "ISC",
+  "license": "Apache-2.0",
   "lint-staged": {
     "*.ts": "prettier --write"
   },


### PR DESCRIPTION
Two unrelated cleanups that were easier to batch than split.

## 1. `package.json#license`: `ISC` → `Apache-2.0`

The repo's `LICENSE` file has been Apache 2.0 as long as it's existed, but `package.json` declared ISC. Consumers inspecting the declared license (`npm view signalk-derived-data license`, npm's package page, dependency scanners, SBOM tools, etc.) saw `ISC` while the shipped `LICENSE` text said `Apache 2.0` — a concrete compliance hazard.

## 2. README rewrite

The previous README was a flat alphabetical-ish list of calculators with at least one duplicate entry (`Magnetic Wind Direction` appeared twice), a few typos (`parallell`, `Velocity Made Goog`), a code example that pointed at `./calcs` (moved to `src/calcs/` in 1.43.0), and no Installation section.

Changes:
- **Installation** — admin UI App Store path + `npm install signalk-derived-data`, plus the `Node >=22` floor.
- **What it calculates** — reorganised into _Environment_, _Navigation_, _Depth_, _Wind_, _Performance_, _Boat state_, _AIS_ groups. Duplicates removed, each entry states its inputs and (where non-obvious) its output path.
- **Writing a new calculator** — example switched to TypeScript (repo is strict TS since 1.43.0). `module.exports = factory` preserved intentionally — the dynamic `load_calcs` loader expects the factory at the top level, not `.default`. The example mirrors `src/calcs/vmg_wind.ts`.
- **Contributing** — pointer back to the repo + the standard dev commands (`npm test`, `npm run typecheck`, `npm run build`, `npm run mutation`).
- Explicit Apache-2.0 footer with a link to `LICENSE`.

No code changes. Tarball diff: README grows from 3.3 kB → 4.8 kB, no other file.