### PR TITLE
fix(index): skip .d.ts and .map siblings when loading calcs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -466,13 +466,19 @@ function load_calcs(
   dir: string
 ): Array<Calculation | Calculation[]> {
   const fpath = path.join(__dirname, dir)
-  const files = fs.readdirSync(fpath)
+  // Whitelist runtime modules: `.js` for the published `dist/` package
+  // and `.ts` for the in-source mocha+tsx test setup. Reject `.d.ts`
+  // declarations and `.map` source maps the build emits alongside each
+  // module — they are not requireable and would crash the loader with
+  // MODULE_NOT_FOUND.
+  const files = fs.readdirSync(fpath).filter((f) => {
+    const ext = path.extname(f)
+    return (ext === '.js' || ext === '.ts') && !f.endsWith('.d.ts')
+  })
   return files
     .map((fname) => {
-      const pgn = path.basename(fname, path.extname(fname))
-      const modulePath = path.join(fpath, pgn)
       // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const mod: CalculationFactory = require(modulePath)
+      const mod: CalculationFactory = require(path.join(fpath, fname))
       return mod(app, plugin)
     })
     .filter((calc): calc is Calculation | Calculation[] => calc != null)


### PR DESCRIPTION
## Summary
- The v1.43.0 TypeScript refactor publishes `.js`, `.js.map`, `.d.ts`, and `.d.ts.map` for every calc in `dist/calcs/`.
- `load_calcs` iterated every file and stripped a single extension, producing un-resolvable specifiers like `airDensity.d` and crashing signalk-server with `MODULE_NOT_FOUND` on startup.
- Whitelist `.js`/`.ts` and reject `.d.ts`, then `require()` the full filename so node never has to guess the extension.

Reported by a user immediately after upgrading to v1.43.0:
\`\`\`
Error: Cannot find module '/home/pi/.signalk/node_modules/signalk-derived-data/dist/calcs/airDensity.d'
\`\`\`

## Test plan
- [x] \`npm run prettier:check\` clean
- [x] \`npm run typecheck\` clean
- [x] \`npm run build\` clean
- [x] \`npm test\` — 255 passing, 1 failing (pre-existing \`moon\` test unrelated to this change)
- [x] Built \`dist/\` and required it from a fresh node process — loader walks all 32 calcs without MODULE_NOT_FOUND