### PR TITLE
fix(loader): isolate require-time failures; magneticVariation lazy init (#236)

### DIFF
--- a/src/calcs/magneticVariation.ts
+++ b/src/calcs/magneticVariation.ts
@@ -4,10 +4,29 @@ import type { Calculation, CalculationFactory } from '../types'
 
 // The WMM-2025 model is expensive to build (it loads spherical harmonic
 // coefficients and constructs lookup tables). Position fixes arrive roughly
-// once per second on a Raspberry Pi, so building the model once at module
-// load and reusing it for every call is a straight win.
-const model = geomagnetism.model()
-const sourceName = (model.name || 'WMM-2025').replace('-', ' ')
+// once per second on a Raspberry Pi, so building the model once and
+// reusing it for every call is a straight win — but the build must be
+// deferred off the module-load path. geomagnetism.model() can throw
+// (missing coefficients, corrupt install, future API break); if that
+// throw escapes require() it takes out the plugin loader in
+// src/index.ts and every other calc with it. Building lazily on first
+// use and memoising a null on failure scopes the problem to this calc.
+type GeoModel = ReturnType<typeof geomagnetism.model>
+let model: GeoModel | null | undefined = undefined
+let sourceName = 'WMM 2025'
+
+function getModel(): GeoModel | null {
+  if (model !== undefined) return model
+  try {
+    const m = geomagnetism.model()
+    sourceName = (m.name || 'WMM-2025').replace('-', ' ')
+    model = m
+    return m
+  } catch {
+    model = null
+    return null
+  }
+}
 
 // Coarse cache: magnetic variation changes on the order of 0.01° per km, so
 // caching by a ~0.1° (≈11 km) lat/lon cell keeps the result well within the
@@ -34,6 +53,8 @@ const factory: CalculationFactory = function (_app, _plugin): Calculation {
     debounceDelay: 10 * 1000,
     calculator: function (position: unknown) {
       if (!isPosition(position)) return
+      const m = getModel()
+      if (!m) return
 
       const latCell = Math.round(position.latitude / CELL_SIZE_DEG)
       const lonCell = Math.round(position.longitude / CELL_SIZE_DEG)
@@ -42,7 +63,7 @@ const factory: CalculationFactory = function (_app, _plugin): Calculation {
       if (latCell === cachedLatCell && lonCell === cachedLonCell) {
         magVar = cachedMagVar!
       } else {
-        const info = model.point([position.latitude, position.longitude])
+        const info = m.point([position.latitude, position.longitude])
         magVar = (info.decl * Math.PI) / 180
         cachedLatCell = latCell
         cachedLonCell = lonCell

--- a/src/calcs/magneticVariation.ts
+++ b/src/calcs/magneticVariation.ts
@@ -26,7 +26,7 @@ const factory: CalculationFactory = function (_app, _plugin): Calculation {
     optionKey: 'magneticVariation',
     title: 'Magnetic Variation',
     derivedFrom: ['navigation.position'],
-    defaults: [undefined, 9999],
+    defaults: [undefined],
     // Magnetic variation changes on the km scale. Even a fast vessel (30 kn)
     // covers only ~150 m per second, so downstream consumers will not notice
     // a 10-second debounce, and it further cuts the emit path on the hot

--- a/src/index.ts
+++ b/src/index.ts
@@ -475,11 +475,24 @@ function load_calcs(
     const ext = path.extname(f)
     return (ext === '.js' || ext === '.ts') && !f.endsWith('.d.ts')
   })
+  // A single calc throwing at require() time must not take down the
+  // rest of the plugin. Calcs frequently import native-ish packages
+  // (geomagnetism's WMM data, baconjs version mismatches, ...) whose
+  // failure modes only show up on a customer's machine, long after
+  // tests have passed. Logging the failure and dropping the calc
+  // keeps every other calc online and gives the customer a filename
+  // to grep for in the server log.
   return files
     .map((fname) => {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const mod: CalculationFactory = require(path.join(fpath, fname))
-      return mod(app, plugin)
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const mod: CalculationFactory = require(path.join(fpath, fname))
+        return mod(app, plugin)
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        app.error(`failed to load calc ${fname}: ${msg}`)
+        return undefined
+      }
     })
     .filter((calc): calc is Calculation | Calculation[] => calc != null)
 }

--- a/test/integration/plugin-loader.ts
+++ b/test/integration/plugin-loader.ts
@@ -1,0 +1,95 @@
+// Integration tests for the calc file loader (load_calcs in src/index.ts).
+//
+// A single calc throwing at require() time must not kill the plugin —
+// the server would then start with ZERO calcs enabled, which matches
+// the user-visible symptom in #236 (magneticVariation null, heading
+// stops updating, etc.). These tests install a synthetic calc that
+// throws the moment Node evaluates its module body, and verify that
+// the remaining calcs still come up.
+
+import * as path from 'path'
+import * as fs from 'fs'
+import * as chai from 'chai'
+chai.should()
+
+function installThrowingCalc(basename: string): () => void {
+  const calcsDir = path.join(__dirname, '../../src/calcs')
+  const fakePath = path.join(calcsDir, basename + '.ts')
+  const indexPath = require.resolve('../../src')
+
+  const origIndexCacheEntry = require.cache[indexPath]
+  fs.writeFileSync(
+    fakePath,
+    "throw new Error('simulated require-time failure')\n"
+  )
+
+  delete require.cache[indexPath]
+  delete require.cache[fakePath]
+
+  return function cleanup() {
+    try {
+      fs.unlinkSync(fakePath)
+    } catch {
+      // ignore — file may already be gone
+    }
+    delete require.cache[fakePath]
+    delete require.cache[indexPath]
+    if (origIndexCacheEntry) require.cache[indexPath] = origIndexCacheEntry
+  }
+}
+
+function makeApp(errors: string[] = []): any {
+  return {
+    selfId: 'self',
+    streambundle: {
+      getSelfStream: () => ({
+        toProperty: () => ({ map: () => ({}), combine: () => ({}) })
+      })
+    },
+    handleMessage: () => {},
+    debug: () => {},
+    error: (msg: string) => errors.push(msg),
+    setPluginStatus: () => {},
+    setPluginError: () => {},
+    getSelfPath: () => undefined,
+    registerDeltaInputHandler: () => {},
+    signalk: { self: 'vessels.self' }
+  }
+}
+
+describe('plugin index.js — load_calcs resilience', () => {
+  it('does not propagate a require-time throw from one calc', () => {
+    const cleanup = installThrowingCalc('__test_throwing_calc')
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const plugin = require('../../src')(makeApp())
+      // schema() is what actually triggers load_calcs. Without the
+      // loader guard this throws and we never get here.
+      const schema = plugin.schema()
+      schema.should.be.an('object')
+      // The other ~35 real calcs must still be present — proving that
+      // the loader isolated the failing module instead of aborting.
+      Object.keys(schema.properties).length.should.be.greaterThan(5)
+    } finally {
+      cleanup()
+    }
+  })
+
+  it('logs an error mentioning the failing calc filename', () => {
+    const errors: string[] = []
+    const cleanup = installThrowingCalc('__test_throwing_named')
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const plugin = require('../../src')(makeApp(errors))
+      plugin.schema()
+      errors
+        .some((e) => e.includes('__test_throwing_named'))
+        .should.equal(
+          true,
+          'expected app.error to be called with the failing filename'
+        )
+    } finally {
+      cleanup()
+    }
+  })
+})

--- a/test/magneticVariation.ts
+++ b/test/magneticVariation.ts
@@ -1,5 +1,6 @@
 import * as chai from 'chai'
 chai.should()
+const expect = chai.expect
 
 import { makeApp, makePlugin } from './helpers'
 
@@ -16,5 +17,49 @@ describe('magneticVariation', () => {
     src.should.exist
     src.value.should.be.a('string')
     src.value.should.not.include('-') // spaces instead of dashes
+  })
+})
+
+// The WMM model build lives at module scope for perf reasons, but the
+// geomagnetism package can throw from .model() (bundler dropped the
+// coefficients, corrupt install, future API break). If that throw
+// escapes module evaluation, the plugin loader in src/index.ts dies
+// and takes *every* other calc down with it — which is exactly what
+// #236 looks like. These tests pin the contract: module eval must
+// survive, and the calculator must no-op rather than crash.
+describe('magneticVariation — geomagnetism load failure', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const geomag: any = require('geomagnetism')
+  const magVarPath = require.resolve('../src/calcs/magneticVariation')
+  let originalModel: any
+
+  beforeEach(() => {
+    originalModel = geomag.model
+  })
+
+  afterEach(() => {
+    geomag.model = originalModel
+    delete require.cache[magVarPath]
+  })
+
+  it('does not throw at require-time when geomagnetism.model() fails', () => {
+    geomag.model = () => {
+      throw new Error('simulated geomagnetism failure')
+    }
+    delete require.cache[magVarPath]
+
+    let factory: any
+    const doRequire = () => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      factory = require('../src/calcs/magneticVariation')
+    }
+    doRequire.should.not.throw()
+
+    // Calculator must degrade to undefined instead of throwing on
+    // every position fix, so headingTrue and friends can detect the
+    // absence and skip their own emit.
+    const d = factory(makeApp(), makePlugin())
+    const out = d.calculator({ latitude: 39.06, longitude: -76.48 })
+    expect(out).to.be.undefined
   })
 })


### PR DESCRIPTION
## Summary

- Build the WMM model lazily in `magneticVariation.ts`. `geomagnetism.model()` previously ran at module eval; any throw from it (missing coefficients, corrupt install, future API break) escaped `require()` and aborted the whole plugin loader.
- Wrap the `require()` inside `load_calcs` in `src/index.ts` so a single broken calc no longer takes the other ~35 offline. Failing filenames go to `app.error` for grep-ability.
- Trim a dead `defaults[1] = 9999` entry on `magneticVariation` that was never read (the stream loop only iterates `derivedFrom` indices). Pure cleanup, no behaviour change.

Fixes [#236](https://github.com/SignalK/signalk-derived-data/issues/236) — the "magneticVariation null, headingTrue not updating" symptom is what a dead loader looks like from the outside, and the lazy init is the most plausible regression between 1.41.0 and 1.43.1. The loader guard is defense in depth for the next time a similar package-load failure bites a different calc.

## Test plan

- [x] `npm test` — 258 passing (up from 255; one pre-existing unrelated `moon.ts` failure carries through).
- [x] `npm run typecheck` — clean.
- [x] `npm run prettier:check` — clean.
- [x] New failing test for loader guard (throwing synthetic calc) goes green only with the `try/catch` applied.
- [x] New failing test for magneticVariation (stubbed `geomagnetism.model()` throws) goes green only with lazy init applied.

## Note on analysis

An earlier attempt on the fork (`b4eeed8` + `21882e2`, dropped from this branch) was cosmetic: it removed the unused `defaults[1] = 9999` entry and claimed it fixed #236. It did not — that entry was dead in v1.41.0 too, which the reporter says works. This PR replaces that with a commit honestly labelled as cleanup, plus the two real fixes above.