### PR TITLE
chore: bump typescript 5.9 -> 6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "signalk-derived-data",
       "version": "1.43.2",
-      "license": "ISC",
+      "license": "Apache-2.0",
       "dependencies": {
         "cubic-spline": "^3.0.3",
         "geolib": "^3.3.1",
@@ -32,7 +32,7 @@
         "prettier": "^3.8.2",
         "rimraf": "^6.1.3",
         "tsx": "^4.21.0",
-        "typescript": "^5.9.3"
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=22"
@@ -4481,9 +4481,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "prettier": "^3.8.2",
     "rimraf": "^6.1.3",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "repository": {
     "type": "git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,10 @@
     "target": "ES2022",
     "module": "commonjs",
     "moduleResolution": "node",
+    // TS 6 turned the legacy `node` (a.k.a. node10) moduleResolution into a
+    // hard deprecation. Silence that so the package can stay on `node` for
+    // now; migrating to `node16` / `bundler` is a separate audit.
+    "ignoreDeprecations": "6.0",
     "lib": ["ES2022"],
 
     "strict": true,
@@ -20,6 +24,9 @@
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
+    // TS 6 tightened the default @types scan: mocha's describe / it globals
+    // no longer leak in unless the test runner is listed here explicitly.
+    "types": ["node", "mocha"],
 
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
## Summary

Aligns with the rest of the SignalK plugin family on typescript `^6.0.3`.

tsconfig additions:
- `ignoreDeprecations: "6.0"` — silences the TS 6 hard deprecation of the legacy `node` moduleResolution. Migrating to `node16` / `bundler` is a separate audit.
- `types: ["node", "mocha"]` — TS 6 tightened the default @types scan; mocha's `describe` / `it` globals no longer leak in automatically.

No source changes required.

## Test plan

- [x] npm run typecheck clean
- [x] npm run build clean
- [x] npm test (1 pre-existing Windows/TZ-only moon test failure, unrelated)
- [x] npm run prettier:check clean
- [ ] CI green on Node 22 + Node 24 with both baconjs versions