### PR TITLE
fix(windGround): emit ground direction to environment.wind.directionGround

### DIFF
--- a/src/calcs/windGround.ts
+++ b/src/calcs/windGround.ts
@@ -49,7 +49,7 @@ const factory: CalculationFactory = function (_app, _plugin): Calculation[] {
         }
 
         return [
-          { path: 'environment.wind.directionTrue', value: dir },
+          { path: 'environment.wind.directionGround', value: dir },
           { path: 'environment.wind.angleTrueGround', value: angle },
           { path: 'environment.wind.speedOverGround', value: speed }
         ]
@@ -59,7 +59,7 @@ const factory: CalculationFactory = function (_app, _plugin): Calculation[] {
           input: [3, 2, null, null],
           selfData,
           expected: [
-            { path: 'environment.wind.directionTrue', value: null },
+            { path: 'environment.wind.directionGround', value: null },
             { path: 'environment.wind.angleTrueGround', value: null },
             { path: 'environment.wind.speedOverGround', value: null }
           ]

--- a/test/windGround.ts
+++ b/test/windGround.ts
@@ -1,7 +1,3 @@
-// Tests marked with `// BUG: ...` lock the CURRENT (incorrect) behaviour
-// of the module so the suite stays green today. A follow-up pass flips
-// those assertions to the correct behaviour and fixes the implementations.
-
 import * as chai from 'chai'
 chai.should()
 
@@ -16,23 +12,12 @@ describe('windGround (extra branches)', () => {
     const ground = arr[0]
     const out = ground.calculator(1.0, 3.0, 5.0, 0.5)
     out.should.have.lengthOf(3)
-    out[0].path.should.equal('environment.wind.directionTrue')
+    out[0].path.should.equal('environment.wind.directionGround')
     out[1].path.should.equal('environment.wind.angleTrueGround')
     out[2].path.should.equal('environment.wind.speedOverGround')
     out[0].value.should.be.closeTo(2.0459686742419585, 1e-9)
     out[1].value.should.be.closeTo(1.0459686742419587, 1e-9)
     out[2].value.should.be.closeTo(2.769931974487608, 1e-9)
-  })
-
-  // BUG: the path for ground-frame wind direction should be
-  // environment.wind.directionGround, but this calculator writes to
-  // environment.wind.directionTrue (water frame per the SK spec). The
-  // deprecated sister calc uses the correct directionGround path.
-  it('writes ground-frame direction to environment.wind.directionTrue (wrong path)', () => {
-    const arr = calcs(makeApp(), makePlugin())
-    const ground = arr[0]
-    const out = ground.calculator(1.0, 3.0, 5.0, 0.5)
-    out[0].path.should.equal('environment.wind.directionTrue')
   })
 
   it('uses awa as the angle when aws is effectively zero', () => {


### PR DESCRIPTION
## Summary

- Move the ground-wind direction output from `environment.wind.directionTrue` to `environment.wind.directionGround`.
- Fixes the "ground direction overwrites true direction" conflict when both calculators are enabled.

## Context

Reported in #186. The main `windGround` calc derives wind direction in the ground frame (uses SOG) but was writing to `environment.wind.directionTrue`, which per the SK spec is the water-frame true wind direction. Tracked in #244.

## Test plan

- [x] Flip the `// BUG:` lock in `test/windGround.ts`
- [x] Assertion on the finite-input case updated to expect `directionGround`
- [x] `npm test` — 300 pass, 1 pre-existing moon failure unrelated to this change