### PR TITLE
fix(batteryPower): correct optionKey spelling to 'batteryPower'

### DIFF
--- a/src/calcs/batteryPower.ts
+++ b/src/calcs/batteryPower.ts
@@ -9,7 +9,7 @@ const factory: CalculationFactory = function (_app, plugin): Calculation[] {
     ]
     return {
       group: 'electrical',
-      optionKey: 'batterPower' + instance,
+      optionKey: 'batteryPower' + instance,
       title: 'Battery ' + instance + ' Power ',
       derivedFrom: function () {
         return derivedFromList

--- a/test/batteryPower.ts
+++ b/test/batteryPower.ts
@@ -1,7 +1,3 @@
-// Tests marked with `// BUG: ...` lock the CURRENT (incorrect) behaviour
-// of the module so the suite stays green today. A follow-up pass flips
-// those assertions to the correct behaviour and fixes the implementations.
-
 import * as chai from 'chai'
 chai.should()
 
@@ -29,11 +25,9 @@ describe('batteryPower', () => {
     out.should.deep.equal([{ path: 'electrical.batteries.0.power', value: 50 }])
   })
 
-  // BUG: the option key is misspelled as 'batterPower' (missing 'y').
-  // Kept as-is because existing user configs depend on the spelling.
-  it('uses the current (misspelled) optionKey', () => {
+  it('uses a per-instance optionKey', () => {
     const arr = calc(makeApp(), makePlugin())
-    arr[0].optionKey.should.equal('batterPower0')
-    arr[1].optionKey.should.equal('batterPower1')
+    arr[0].optionKey.should.equal('batteryPower0')
+    arr[1].optionKey.should.equal('batteryPower1')
   })
 })


### PR DESCRIPTION
## Summary

- Rename the per-instance `optionKey` from `batterPower<N>` to `batteryPower<N>`.
- Breaking change: users with this calculator enabled under the old key will need to re-enable it under the new key.

## Context

Typo reported in #186. Tracked in #244. No migration shim; the rename is aligned with the v2 major bump.

## Test plan

- [x] Flip the `// BUG:` lock in `test/batteryPower.ts`
- [x] `npm test` — 301 pass, 1 pre-existing moon failure unrelated to this change