### PR TITLE
docs: clarify environment.current.driftImpact is plugin-specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,10 @@ paths and emits on one or more output paths.
 
 - **Distance to go** from `courseGreatCircle.nextPoint.position`
 - **Set and drift** from heading, course over ground, speed
-  through water, speed over ground, and magnetic variation
+  through water, speed over ground, and magnetic variation. Writes
+  `environment.current.drift`, `setTrue`, `setMagnetic`, plus
+  `environment.current.driftImpact` — the last of these is a
+  plugin-specific extension, not part of the Signal K spec.
 - **True course over ground** from magnetic COG + magnetic variation
 - **Magnetic course over ground** from true COG + magnetic variation
 - **ETA** to the active waypoint

--- a/test/setDrift.ts
+++ b/test/setDrift.ts
@@ -29,7 +29,7 @@ describe('setDrift — frame mismatch regression', () => {
     setTrue.value.should.be.closeTo(4.303481965647525, 1e-9)
   })
 
-  // BUG: environment.current.driftImpact is not a SignalK spec path.
+  // environment.current.driftImpact is not a SignalK spec path.
   // The other three outputs are valid spec paths.
   it('emits the non-spec environment.current.driftImpact path', () => {
     const d = calc(makeApp(), makePlugin())


### PR DESCRIPTION
## Summary

- Document in the Set-and-drift README bullet that `environment.current.driftImpact` is a plugin-specific extension, not part of the Signal K spec.
- Drop the `BUG:` label from the matching comment in `test/setDrift.ts` — the path is documented behaviour, not a bug.
- The other three outputs (`drift`, `setTrue`, `setMagnetic`) remain standard spec paths.

## Context

Flagged in #186. Documentation-only — no behaviour change.

## Test plan

- [x] README renders correctly