### PR TITLE
fix(depth): align transducerToKeel sign convention with SignalK spec

### DIFF
--- a/src/calcs/depthBelowKeel2.ts
+++ b/src/calcs/depthBelowKeel2.ts
@@ -20,7 +20,7 @@ const factory: CalculationFactory = function (app): Calculation {
         return undefined
       }
 
-      const value = depthBelowTransducer + depthTransducerToKeel
+      const value = depthBelowTransducer - depthTransducerToKeel
 
       if (isNaN(value)) {
         return undefined

--- a/src/calcs/transducerToKeel.ts
+++ b/src/calcs/transducerToKeel.ts
@@ -24,7 +24,7 @@ const factory: CalculationFactory = function (app): Calculation {
         return undefined
       }
 
-      const transducerToKeel = surfaceToTransducer - cachedDraft
+      const transducerToKeel = cachedDraft - surfaceToTransducer
 
       if (isNaN(transducerToKeel)) {
         return undefined

--- a/test/depthBelowKeel2.ts
+++ b/test/depthBelowKeel2.ts
@@ -8,9 +8,9 @@ describe('depthBelowKeel2', () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const calc: any = require('../src/calcs/depthBelowKeel2')
 
-  it('adds belowTransducer + transducerToKeel', () => {
+  it('subtracts transducerToKeel from belowTransducer', () => {
     const app = makeApp({
-      selfPaths: { environment: { depth: { transducerToKeel: { value: -1 } } } }
+      selfPaths: { environment: { depth: { transducerToKeel: { value: 1 } } } }
     })
     const d = calc(app, makePlugin())
     const out = d.calculator(9)

--- a/test/transducerToKeel.ts
+++ b/test/transducerToKeel.ts
@@ -1,7 +1,3 @@
-// Tests marked with `// BUG: ...` lock the CURRENT (incorrect) behaviour
-// of the module so the suite stays green today. A follow-up pass flips
-// those assertions to the correct behaviour and fixes the implementations.
-
 import * as chai from 'chai'
 chai.should()
 const expect = chai.expect
@@ -12,20 +8,14 @@ describe('transducerToKeel', () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const calc: any = require('../src/calcs/transducerToKeel')
 
-  // BUG: the formula `surfaceToTransducer - draft` produces a negative
-  // result when draft > surfaceToTransducer, which contradicts the
-  // SignalK spec (transducerToKeel should be positive when the keel is
-  // below the transducer). depthBelowKeel2.js then compensates with an
-  // addition. Both files are internally consistent but inconsistent
-  // with the spec.
-  it('returns surfaceToTransducer - draft (current sign convention)', () => {
+  it('returns draft - surfaceToTransducer (positive when keel is below transducer)', () => {
     const app = makeApp({
       selfPaths: { design: { draft: { value: { maximum: 1.5 } } } }
     })
     const d = calc(app, makePlugin())
     const out = d.calculator(0.5)
     out.should.deep.equal([
-      { path: 'environment.depth.transducerToKeel', value: -1 }
+      { path: 'environment.depth.transducerToKeel', value: 1 }
     ])
   })
 


### PR DESCRIPTION
## Summary

Coordinated sign fix for the two files that produced and consumed `environment.depth.transducerToKeel`:

- `transducerToKeel.ts`: `surfaceToTransducer - draft` -> `draft - surfaceToTransducer` (positive when keel is below transducer, per spec).
- `depthBelowKeel2.ts`: `belowTransducer + transducerToKeel` -> `belowTransducer - transducerToKeel`.

## Context

Reported in #186; queued for v2 in #244.

The two files were internally consistent (the two cancelling sign errors produced the right `belowKeel`), but a `transducerToKeel` stream coming from any other source (hardware sensor, another plugin) with the spec-compliant positive sign would have given a wrong `belowKeel`. They must change together, so they ship in one PR.

## Test plan

- [x] Flip the `// BUG:` lock in `test/transducerToKeel.ts` (expects +1, was -1)
- [x] Update the `depthBelowKeel2` test to provide `transducerToKeel: 1` (positive) and cover the new subtraction
- [x] `npm test` — 301 pass, 1 pre-existing moon failure unrelated to this change