### PR TITLE
chore(cpa_tcpa): reorder config, rename distanceToSelf, fix defaults

### DIFF
--- a/src/calcs/cpa_tcpa.ts
+++ b/src/calcs/cpa_tcpa.ts
@@ -75,22 +75,23 @@ const factory: CalculationFactory = function (app, plugin): Calculation {
       'navigation.speedOverGround'
     ],
     properties: {
+      distanceToSelf: {
+        type: 'boolean',
+        title:
+          'Calculate distance to self for all vessels within RANGE and TIME limit',
+        default: true
+      },
       range: {
         type: 'number',
         title:
           'Calculate for all vessels within this range (m), negative to disable filter',
-        default: 1852
-      },
-      distanceToSelf: {
-        type: 'boolean',
-        title: 'Calculate distance to self for all vessels',
-        default: true
+        default: -1
       },
       timelimit: {
         type: 'number',
         title:
           'Discard other vessel data if older than this (in seconds), negative to disable filter',
-        default: 30
+        default: 1800
       },
       sendNotifications: {
         type: 'boolean',

--- a/test/cpa_tcpa.ts
+++ b/test/cpa_tcpa.ts
@@ -46,6 +46,17 @@ describe('cpa_tcpa', () => {
     return new Date(Date.now() + (offsetSec || 0) * 1000).toISOString()
   }
 
+  it('exposes the plug-and-play defaults (distanceToSelf on, range off, 30 min timelimit)', () => {
+    const d = calcFactory(cpaApp({ vessels: {} }), cpaPlugin())
+    const props = d.properties
+    props.distanceToSelf.default.should.equal(true)
+    props.range.default.should.equal(-1)
+    props.timelimit.default.should.equal(1800)
+    Object.keys(props)
+      .slice(0, 3)
+      .should.deep.equal(['distanceToSelf', 'range', 'timelimit'])
+  })
+
   it('returns [] and emits nothing when no vessels are tracked', () => {
     const handled: any[] = []
     const app = cpaApp({ vessels: {}, handled })


### PR DESCRIPTION
## Summary
- Reorders traffic config: `distanceToSelf` first, then `range`, then `timelimit`, so the UI reads top-to-bottom as users actually need to configure it.
- Renames `distanceToSelf` title to `Calculate distance to self for all vessels within RANGE and TIME limit` so the dependency on the range/time filters is explicit.
- Changes `range` default to `-1` (filter off) and `timelimit` default to `1800` s, giving a plug-and-play experience inside Freeboard-SK.

Closes https://github.com/SignalK/signalk-derived-data/issues/168.

## Test plan
- [x] `npm test` (301 passing, 1 pre-existing moon failure unrelated to this change)
- [x] `npm run typecheck`
- [x] `npm run prettier:check`