### PR TITLE
refactor: use @signalk/server-api types in ServerApp / Position

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "suncalc": "^1.8.0"
       },
       "devDependencies": {
+        "@signalk/server-api": "^2.24.0",
         "@stryker-mutator/core": "^9.6.1",
         "@stryker-mutator/mocha-runner": "^9.6.1",
         "@types/chai": "^4.3.20",
@@ -1486,6 +1487,19 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@js-temporal/polyfill": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.5.1.tgz",
+      "integrity": "sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "jsbi": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1501,6 +1515,25 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
       "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@signalk/server-api": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/@signalk/server-api/-/server-api-2.24.0.tgz",
+      "integrity": "sha512-IZWVIuV/vOG4obKZ7vhUCfZ19XhpmXlUq8MNV9G10S6vF2vBKZ6JiOaYVVAyzbihlzPafD4Mq7wGurvWur1a0g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@js-temporal/polyfill": "^0.5.1",
+        "@sinclair/typebox": "^0.34.0",
+        "baconjs": "^3.0.0"
+      }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
       "dev": true,
       "license": "MIT"
     },
@@ -3009,6 +3042,13 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/jsbi": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.2.tgz",
+      "integrity": "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/jsesc": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "suncalc": "^1.8.0"
   },
   "devDependencies": {
+    "@signalk/server-api": "^2.24.0",
     "@stryker-mutator/core": "^9.6.1",
     "@stryker-mutator/mocha-runner": "^9.6.1",
     "@types/chai": "^4.3.20",

--- a/src/index.ts
+++ b/src/index.ts
@@ -557,7 +557,7 @@ const createPlugin = function (app: ServerApp): PluginState {
       })
       delete traffic.notificationRange
       delete traffic.notificationTimeLimit
-      app.savePluginOptions?.(plugin.properties!)
+      app.savePluginOptions(plugin.properties!, () => undefined)
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,18 @@
 /**
  * Shared types for the signalk-derived-data plugin.
  *
- * `ServerApp` is the minimal shape of the Signal K server instance the
- * plugin actually touches at runtime (streambundle, logging helpers,
- * plugin hooks). The real server passes in a much larger object; we
- * only type what this plugin reads so the types stay honest without
- * taking a dependency on the server's full API.
+ * `ServerApp` extends `ServerAPI` from `@signalk/server-api`, overriding
+ * `streambundle`, `handleMessage`, and `registerDeltaInputHandler` to
+ * use the plugin's local `SignalKDelta` shape and the reduced
+ * `BaconStream`/`StreamBundle` types. The local delta types use
+ * unbranded path strings and per-value timestamps, which the server-api
+ * branded `Delta`/`PathValue` types do not model. The reduced bacon
+ * shape keeps the plugin runnable against both baconjs 1.x and 3.x.
  */
+
+import type { ServerAPI } from '@signalk/server-api'
+
+export type { Position } from '@signalk/server-api'
 
 // Bacon.js stream shape reduced to the methods the plugin uses. Both
 // baconjs 1.x and 3.x expose these, which is why the plugin avoids
@@ -130,25 +136,18 @@ export interface PluginInstance {
   [key: string]: unknown
 }
 
-export interface ServerApp {
-  selfId: string
-  debug: (msg: string, ...args: unknown[]) => void
-  error: (msg: string, ...args: unknown[]) => void
-  getSelfPath: (path: string) => unknown
-  getPath: (path: string) => unknown
-  handleMessage: (pluginId: string, delta: SignalKDelta) => void
+export interface ServerApp extends Omit<
+  ServerAPI,
+  'streambundle' | 'handleMessage' | 'registerDeltaInputHandler'
+> {
+  // Local overrides keep the plugin working with the unbranded path
+  // strings the calculators emit and with the reduced StreamBundle
+  // shape that abstracts over baconjs versions.
   streambundle: StreamBundle
-  savePluginOptions?: (props: PluginProperties) => void
-  setPluginStatus?: (msg: string) => void
-  setPluginError?: (msg: string) => void
-  // The server threads each inbound delta through a chain of input
-  // handlers. A handler must call `next(delta)` (possibly with a
-  // mutated copy) to forward it to the next handler in the chain;
-  // skipping the call drops the delta.
+  handleMessage: (pluginId: string, delta: SignalKDelta) => void
   registerDeltaInputHandler?: (
     fn: (delta: SignalKDelta, next: (delta: SignalKDelta) => void) => void
   ) => void
-  signalk?: { self?: unknown }
 }
 
 export interface SignalKPluginDefinition {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,10 @@
  * them without pulling in lodash or geolib.
  */
 
+import type { Position } from '@signalk/server-api'
+
+export type { Position }
+
 /**
  * @description Tests that supplied value is a number
  * @param value Value to test
@@ -42,11 +46,6 @@ export const formatCompassAngle = (value: unknown): number | null => {
   } else {
     return null
   }
-}
-
-export interface Position {
-  latitude: number
-  longitude: number
 }
 
 /**


### PR DESCRIPTION
## Summary

Replace the local restatement of `ServerAPI` and `Position` with imports from `@signalk/server-api`.

- `ServerApp` now extends `Omit<ServerAPI, 'streambundle' | 'handleMessage' | 'registerDeltaInputHandler'>`. The three excluded members are kept with the plugin's local types because the calculators emit unbranded path strings, support per-value timestamps that the server-api branded `PathValue` does not model, and consume the reduced `StreamBundle`/`BaconStream` shape that abstracts over baconjs versions.
- `Position` is re-exported from `@signalk/server-api` (was a local duplicate in `utils.ts`).
- The one `savePluginOptions` call site is adjusted to provide the now-required completion callback per the canonical `ServerAPI` signature.

The remaining local types (`SignalKDelta`, `SignalKUpdate`, `SignalKValue`, `BaconStream`, `BaconProperty`, `StreamBundle`) are deliberately kept local for the reasons documented in `types.ts`.

`@signalk/server-api` is added as a `devDependency` (types-only consumption; runtime instances come from the host server).

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] `npm test` passes (312 tests)
- [x] `npm run prettier:check` passes