### PR TITLE
chore(deps-dev): bump @types/chai to ^5.2.3 and prettier to ^3.8.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@signalk/server-api": "^2.24.0",
         "@stryker-mutator/core": "^9.6.1",
         "@stryker-mutator/mocha-runner": "^9.6.1",
-        "@types/chai": "^4.3.20",
+        "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
         "@types/node": "^22.19.17",
         "@types/suncalc": "^1.9.2",
@@ -30,7 +30,7 @@
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
         "mocha": "^11.7.5",
-        "prettier": "^3.8.2",
+        "prettier": "^3.8.3",
         "rimraf": "^6.1.3",
         "tsx": "^4.21.0",
         "typescript": "^6.0.3"
@@ -1658,9 +1658,20 @@
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {
-      "version": "4.3.20",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.20.tgz",
-      "integrity": "sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1770,6 +1781,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/baconjs": {
       "version": "3.0.23",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@signalk/server-api": "^2.24.0",
     "@stryker-mutator/core": "^9.6.1",
     "@stryker-mutator/mocha-runner": "^9.6.1",
-    "@types/chai": "^4.3.20",
+    "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
     "@types/node": "^22.19.17",
     "@types/suncalc": "^1.9.2",
@@ -94,7 +94,7 @@
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "mocha": "^11.7.5",
-    "prettier": "^3.8.2",
+    "prettier": "^3.8.3",
     "rimraf": "^6.1.3",
     "tsx": "^4.21.0",
     "typescript": "^6.0.3"

--- a/test/chai-setup.ts
+++ b/test/chai-setup.ts
@@ -1,0 +1,7 @@
+// Activates chai's should-style assertions for the whole test suite.
+// In @types/chai 5.x the `Object.should` global augmentation moved out
+// of the main entry into this side-effect module, so importing it once
+// here is enough for TypeScript to apply the augmentation across every
+// test file. The runtime `chai.should()` calls in individual tests keep
+// working (they're idempotent), so we don't have to touch each file.
+import 'chai/register-should'


### PR DESCRIPTION
Supersedes #255 (Dependabot's `@types/chai` 4 → 5 bump) and rolls in the latest `prettier` patch in the same PR.

## Changes

- `@types/chai` `^4.3.20` → `^5.2.3`
- `prettier` `^3.8.2` → `^3.8.3`
- New `test/chai-setup.ts` — single side-effect `import 'chai/register-should'`. In `@types/chai` 5.x the `Object.should` global type augmentation moved out of the main entry into a separate `register-should` module, so importing it once for the test project keeps the existing `chai.should()` calls in every test file working under TypeScript without touching all 37 of them.

## Held back

`@types/node` (22 → 25) is intentionally pinned to `^22.x` to track `engines.node >=22`. Bumping the major would let TypeScript accept APIs that don't exist on the minimum supported runtime.

## Verification

- `npm run typecheck` — clean
- `npm run build` — clean
- `npm test` — 312 passing
- `npm run prettier:check` — clean