### PR TITLE
fix(cpa_tcpa): keep distanceToSelf for anchored vessels with sparse AIS

### DIFF
--- a/src/calcs/cpa_tcpa.ts
+++ b/src/calcs/cpa_tcpa.ts
@@ -20,6 +20,11 @@ const METERS_PER_DEG = 111319
 // every visible AIS target.
 const DISTANCE_TO_SELF_EPSILON = 1
 
+// Default cleanup window (seconds) after which an AIS vessel's
+// distanceToSelf is dropped. 1h survives normal Class A/B reporting gaps
+// for anchored/moored vessels while still pruning truly-disappeared ones.
+const DEFAULT_DISTANCE_TO_SELF_TIMELIMIT_SEC = 3600
+
 interface VesselLike {
   location: { lon: number; lat: number }
   speed: number
@@ -92,6 +97,12 @@ const factory: CalculationFactory = function (app, plugin): Calculation {
         title:
           'Discard other vessel data if older than this (in seconds), negative to disable filter',
         default: 1800
+      },
+      distanceToSelfTimelimit: {
+        type: 'number',
+        title:
+          'Discard distanceToSelf if vessel position is older than this (in seconds), negative to disable filter. Lets anchored/moored vessels keep a distance even when their AIS reports are minutes apart.',
+        default: DEFAULT_DISTANCE_TO_SELF_TIMELIMIT_SEC
       },
       sendNotifications: {
         type: 'boolean',
@@ -166,6 +177,7 @@ const factory: CalculationFactory = function (app, plugin): Calculation {
         range: number
         timelimit: number
         distanceToSelf?: boolean
+        distanceToSelfTimelimit?: number
         sendNotifications?: boolean
         notificationZones: Array<{
           range: number
@@ -178,6 +190,17 @@ const factory: CalculationFactory = function (app, plugin): Calculation {
       const rangeActive = range >= 0
       const timelimit = traffic.timelimit
       const distanceToSelfEnabled = traffic.distanceToSelf
+      // distanceToSelfTimelimit decouples "vessel disappeared" cleanup from
+      // the (much shorter) CPA freshness window. An anchored or moored
+      // vessel may only emit an AIS position every few minutes, well past
+      // `timelimit`, but we still want to show its distance until the boat
+      // genuinely drops off the network. Negative disables the time-based
+      // cleanup; the post-loop sweep below still prunes vessels that drop
+      // out of the vessel list, which keeps `lastDistanceToSelf` bounded.
+      const distanceToSelfTimelimit =
+        traffic.distanceToSelfTimelimit ??
+        DEFAULT_DISTANCE_TO_SELF_TIMELIMIT_SEC
+      const distanceToSelfStaleActive = distanceToSelfTimelimit >= 0
       const sendNotifications =
         traffic.sendNotifications === undefined || traffic.sendNotifications
       const notificationZones = traffic.notificationZones
@@ -241,7 +264,18 @@ const factory: CalculationFactory = function (app, plugin): Calculation {
         const posNode = nav.position
         const posTimestamp = posNode && posNode.timestamp
 
-        if (isStale(currentMs, posTimestamp, timelimit)) {
+        // Two-tier staleness on position:
+        //   1) `distanceToSelfTimelimit` (long, default 1h) is the
+        //      "vessel disappeared" gate — if the position is older than
+        //      that, drop both distanceToSelf and CPA.
+        //   2) `timelimit` (short, default 30s) is the CPA freshness gate
+        //      — if the position is older than that but still within the
+        //      long window, we keep emitting distanceToSelf (so anchored/
+        //      moored vessels stay visible) and null out CPA.
+        if (
+          distanceToSelfStaleActive &&
+          isStale(currentMs, posTimestamp, distanceToSelfTimelimit)
+        ) {
           app.debug('old position of vessel, not calculating')
           const currentDistanceToSelf =
             nav.distanceToSelf && nav.distanceToSelf.value
@@ -264,6 +298,8 @@ const factory: CalculationFactory = function (app, plugin): Calculation {
           }
           continue
         } // old data from vessel, not calculating
+
+        const positionStaleForCpa = isStale(currentMs, posTimestamp, timelimit)
 
         const vesselPos = posNode && posNode.value
         if (typeof vesselPos !== 'undefined') {
@@ -324,6 +360,7 @@ const factory: CalculationFactory = function (app, plugin): Calculation {
           } // if distance outside range, don't calculate
 
           if (
+            positionStaleForCpa ||
             isStale(
               currentMs,
               nav.courseOverGroundTrue?.timestamp,
@@ -449,6 +486,20 @@ const factory: CalculationFactory = function (app, plugin): Calculation {
           deltas.push(normalAlarmDelta(selfId, vessel))
           delete alarmSent[vessel]
         })
+
+      // Drop dedupe-cache entries for vessels that have dropped out of
+      // the vessel tree entirely. The time-based stale gate above also
+      // does this when it fires, but it's gated by
+      // `distanceToSelfStaleActive`; this sweep keeps the cache bounded
+      // even when the operator sets `distanceToSelfTimelimit < 0` and on
+      // busy AIS feeds where transient targets accumulate over time.
+      if (vesselList) {
+        for (const vessel of Object.keys(lastDistanceToSelf)) {
+          if (!(vessel in vesselList)) {
+            delete lastDistanceToSelf[vessel]
+          }
+        }
+      }
 
       return deltas
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -119,6 +119,7 @@ export interface PluginProperties {
     }>
     range?: number
     distanceToSelf?: boolean
+    distanceToSelfTimelimit?: number
     timelimit?: number
   }
   [key: string]: unknown

--- a/test/cpa_tcpa.ts
+++ b/test/cpa_tcpa.ts
@@ -285,26 +285,167 @@ describe('cpa_tcpa', () => {
     expect(dist.updates[0].values[0].value).to.be.greaterThan(100000)
   })
 
-  it('emits null distanceToSelf + null CPA when the position timestamp is stale', () => {
+  it('emits null distanceToSelf + null CPA when the position is older than distanceToSelfTimelimit', () => {
+    // Vessel position is 2 min old AND distanceToSelfTimelimit is 30s, so
+    // it's past the long "vessel disappeared" window. Both CPA and the
+    // previously-emitted distanceToSelf get nulled out.
     const vessels = {
       other: {
         navigation: {
           position: {
             value: { latitude: 0.0001, longitude: 0 },
-            timestamp: iso(-120) // 2 min ago, stale
+            timestamp: iso(-120) // 2 min ago
           },
           distanceToSelf: { value: 10 }
         }
       }
     }
     const app = cpaApp({ vessels })
-    const d = calcFactory(app, cpaPlugin({ timelimit: 30 }))
+    const d = calcFactory(
+      app,
+      cpaPlugin({ timelimit: 30, distanceToSelfTimelimit: 30 })
+    )
     const out = d.calculator({ latitude: 0, longitude: 0 }, 0, 0)
     const nullCpa = out.find(
       (x: any) => x.updates[0].values[0].path === 'navigation.closestApproach'
     )
     expect(nullCpa).to.exist
     expect(nullCpa.updates[0].values[0].value).to.equal(null)
+  })
+
+  it('keeps emitting distanceToSelf for an anchored vessel whose position is past timelimit but within distanceToSelfTimelimit', () => {
+    // Position is 5 min old — past the 30s CPA freshness window but well
+    // inside the 1 hour distanceToSelf window. Distance is still emitted
+    // (so Freeboard SK keeps showing the boat) and CPA is nulled out
+    // because the position is too old to project forward safely.
+    const handled: any[] = []
+    const vessels = {
+      other: {
+        navigation: {
+          position: {
+            value: { latitude: 0.0001, longitude: 0 },
+            timestamp: iso(-300)
+          },
+          courseOverGroundTrue: { value: 0, timestamp: iso(-300) },
+          speedOverGround: { value: 0, timestamp: iso(-300) }
+        }
+      }
+    }
+    const app = cpaApp({ vessels, handled })
+    const d = calcFactory(
+      app,
+      cpaPlugin({ timelimit: 30, distanceToSelfTimelimit: 3600 })
+    )
+    const out = d.calculator({ latitude: 0, longitude: 0 }, 0, 0)
+    const distDelta = handled.find(
+      (x: any) =>
+        x.updates[0].values[0].path === 'navigation.distanceToSelf' &&
+        typeof x.updates[0].values[0].value === 'number'
+    )
+    expect(distDelta).to.exist
+    // 0.0001 deg of latitude is ~11.1 m; pin a tight range so a regression
+    // that emits a stale or zero value (instead of recomputing) is caught.
+    expect(distDelta.updates[0].values[0].value).to.be.within(10, 13)
+    const cpaDelta = out.find(
+      (x: any) => x.updates[0].values[0].path === 'navigation.closestApproach'
+    )
+    expect(cpaDelta).to.exist
+    expect(cpaDelta.updates[0].values[0].value).to.equal(null)
+  })
+
+  it('emits distanceToSelf for a long-stale vessel when distanceToSelfTimelimit is negative', () => {
+    // distanceToSelfTimelimit: -1 disables the long cleanup gate, so a
+    // 1-day-old position still produces a distance. CPA is still nulled
+    // because timelimit (30s) governs CPA freshness independently.
+    const handled: any[] = []
+    const vessels = {
+      other: {
+        navigation: {
+          position: {
+            value: { latitude: 0.0005, longitude: 0 },
+            timestamp: iso(-86400)
+          },
+          courseOverGroundTrue: { value: 0, timestamp: iso(-86400) },
+          speedOverGround: { value: 0, timestamp: iso(-86400) }
+        }
+      }
+    }
+    const app = cpaApp({ vessels, handled })
+    const d = calcFactory(
+      app,
+      cpaPlugin({ timelimit: 30, distanceToSelfTimelimit: -1, range: -1 })
+    )
+    const out = d.calculator({ latitude: 0, longitude: 0 }, 0, 0)
+    const distDelta = handled.find(
+      (x: any) => x.updates[0].values[0].path === 'navigation.distanceToSelf'
+    )
+    expect(distDelta).to.exist
+    // 0.0005 deg of latitude is ~55.6 m.
+    expect(distDelta.updates[0].values[0].value).to.be.within(50, 60)
+    const cpaDelta = out.find(
+      (x: any) => x.updates[0].values[0].path === 'navigation.closestApproach'
+    )
+    expect(cpaDelta).to.exist
+    expect(cpaDelta.updates[0].values[0].value).to.equal(null)
+  })
+
+  it('prunes lastDistanceToSelf for vessels that drop out of the vessel tree', () => {
+    // The post-loop sweep must clear cached entries for vessels no longer
+    // in `vesselList`, otherwise a long-running plugin process accumulates
+    // entries indefinitely on busy AIS feeds. The proof is that a vessel
+    // re-appearing at the same position re-emits the distance (which would
+    // be skipped by the epsilon dedupe if the cache had survived).
+    const handled: any[] = []
+    let vessels: any = {
+      other: {
+        navigation: {
+          position: {
+            value: { latitude: 0.001, longitude: 0 },
+            timestamp: iso()
+          },
+          courseOverGroundTrue: { value: 0, timestamp: iso() },
+          speedOverGround: { value: 0, timestamp: iso() }
+        }
+      }
+    }
+    const app: any = {
+      debug: () => {},
+      error: () => {},
+      selfId: 'self',
+      handleMessage: (_: unknown, delta: unknown) => handled.push(delta),
+      getPath: (p: string) => getPath({ vessels }, p),
+      getSelfPath: () => undefined
+    }
+    const d = calcFactory(app, cpaPlugin({ distanceToSelf: true, range: -1 }))
+    d.calculator({ latitude: 0, longitude: 0 }, 0, 0)
+    handled
+      .filter(
+        (x: any) => x.updates[0].values[0].path === 'navigation.distanceToSelf'
+      )
+      .should.have.length(1)
+    // Vessel disappears entirely (e.g. dropped from AIS subscription).
+    vessels = {}
+    d.calculator({ latitude: 0, longitude: 0 }, 0, 0)
+    // Re-appears at the SAME position. With the cache pruned by the
+    // post-loop sweep, the epsilon dedupe sees a fresh entry and re-emits.
+    vessels = {
+      other: {
+        navigation: {
+          position: {
+            value: { latitude: 0.001, longitude: 0 },
+            timestamp: iso()
+          },
+          courseOverGroundTrue: { value: 0, timestamp: iso() },
+          speedOverGround: { value: 0, timestamp: iso() }
+        }
+      }
+    }
+    d.calculator({ latitude: 0, longitude: 0 }, 0, 0)
+    handled
+      .filter(
+        (x: any) => x.updates[0].values[0].path === 'navigation.distanceToSelf'
+      )
+      .should.have.length(2)
   })
 
   it('pushes a null CPA delta when course/speed timestamps are older than the timelimit', () => {


### PR DESCRIPTION
## Summary

- Decouples the `distanceToSelf` cleanup window from the CPA freshness window, so anchored or moored vessels (which only emit AIS positions every few minutes) keep showing up in consumers like Freeboard SK instead of flickering out every 30 seconds.
- Adds a new `traffic.distanceToSelfTimelimit` plugin option (default `3600` seconds, negative disables). Position older than `timelimit` (default 30s) but newer than `distanceToSelfTimelimit` now emits a fresh distance and a `null` CPA. Position older than `distanceToSelfTimelimit` continues to drop both, as before.
- Adds a post-loop sweep that prunes `lastDistanceToSelf` cache entries for vessels no longer in the vessel tree, so the dedupe cache stays bounded even when the time-based gate is disabled or set very long.

Closes [SignalK/signalk-derived-data#169](https://github.com/SignalK/signalk-derived-data/issues/169).

## Behavior change for existing users

With default settings, vessels are now retained for 1 hour instead of 30 seconds. CPA is still gated by the short `timelimit`. Set `distanceToSelfTimelimit` to a smaller value (or to `-1` to disable the time-based gate entirely) if a different cleanup window is preferred.

## Out of scope (noted during review)

- `isStale` returns `false` for non-finite parses of the timestamp string — pre-existing weakness, worth a separate hardening PR.
- Schema bound (`minimum`) on the new option could reject NaN at config-load time.

## Test plan

- [x] `npm test` (304 passing; the single failure in `moon.ts` is pre-existing on master and unrelated).
- [x] `npm run typecheck`, `npm run prettier:check`, `npm run build` all clean.
- [x] New tests cover: anchored vessel (CPA-stale, distance-fresh), negative `distanceToSelfTimelimit` disabling the gate, and post-loop cache pruning when a vessel drops out of the tree.