### PR TITLE
chore: lower Node floor to >=20.10 for Venus CerboGX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22.x, 24.x]
+        node-version: [20.x, 22.x, 24.x]
         # Dual baconjs matrix exists because Cerbo GX / Venus OS still
         # bundles an older signalk-server that pins baconjs 1.x in
         # `node_modules`, while upstream signalk-server is on baconjs

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "sideEffects": false,
   "engines": {
-    "node": ">=22"
+    "//": "Floor at 20.10 to support Venus CerboGX firmware (currently Node 20.18.2). Bump back to >=22 once Cerbo ships a newer Node.",
+    "node": ">=20.10"
   },
   "files": [
     "dist",


### PR DESCRIPTION
Cerbo GX firmware ships Node 20.18.2 and users can't upgrade. The current `>=22` pin (set during the modernize wave) blocks the plugin from installing under strict-engines installers.

The source uses no Node 22-only APIs — `structuredClone`, `fetch`, `node:test` etc. all exist on 20.10+, and `tsconfig.target` is `ES2022` which Node 20.10 supports fully. Bump is safe.

Changes:
- `engines.node`: `>=22` -> `>=20.10`
- CI matrix: `[22.x, 24.x]` -> `[20.x, 22.x, 24.x]` so a future Node 20 regression is caught
- `//` comment inside the engines block (npm strips `//` at publish) explaining the rationale

**Bump back to `>=22` once Cerbo ships a newer Node.**