### PR TITLE
fix: adapt to suncalc v2 breaking changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "geolib": "^3.3.1",
         "geolocation-utils": "^1.2.3",
         "geomagnetism": "^0.2.0",
-        "suncalc": "^1.8.0"
+        "suncalc": "^2.0.0"
       },
       "devDependencies": {
         "@signalk/server-api": "^2.24.0",
@@ -22,7 +22,6 @@
         "@types/chai": "^5.2.3",
         "@types/mocha": "^10.0.10",
         "@types/node": "^26.0.0",
-        "@types/suncalc": "^1.9.2",
         "baconjs": "^3.0.0",
         "c8": "^11.0.0",
         "chai": "^6.2.2",
@@ -1707,13 +1706,6 @@
       "dependencies": {
         "undici-types": "~8.3.0"
       }
-    },
-    "node_modules/@types/suncalc": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@types/suncalc/-/suncalc-1.9.2.tgz",
-      "integrity": "sha512-ATAGBHHfA1TlE2tjfidLyTcysjoT2JHHEAmWRULh73SU9UTn++j5fqHEW16X6Y/2Li87jEQXzgu4R/OOdlDqzw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/ajv": {
       "version": "8.18.0",
@@ -4262,9 +4254,9 @@
       }
     },
     "node_modules/suncalc": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/suncalc/-/suncalc-1.9.0.tgz",
-      "integrity": "sha512-vMJ8Byp1uIPoj+wb9c1AdK4jpkSKVAywgHX0lqY7zt6+EWRRC3Z+0Ucfjy/0yxTVO1hwwchZe4uoFNqrIC24+A=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/suncalc/-/suncalc-2.0.0.tgz",
+      "integrity": "sha512-RcO28GOMXNnB+sr+c7/+zv5UPMa9wxIsUVGE3HddjQykqCVEC2rc4t4IjBB7qaa7K7dx5Cxp8UZwexyXrX8JkA=="
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "geolib": "^3.3.1",
     "geolocation-utils": "^1.2.3",
     "geomagnetism": "^0.2.0",
-    "suncalc": "^1.8.0"
+    "suncalc": "^2.0.0"
   },
   "devDependencies": {
     "@signalk/server-api": "^2.24.0",
@@ -96,7 +96,6 @@
     "@types/chai": "^5.2.3",
     "@types/mocha": "^10.0.10",
     "@types/node": "^26.0.0",
-    "@types/suncalc": "^1.9.2",
     "baconjs": "^3.0.0",
     "c8": "^11.0.0",
     "chai": "^6.2.2",

--- a/src/calcs/moon.ts
+++ b/src/calcs/moon.ts
@@ -1,5 +1,5 @@
 import * as suncalc from 'suncalc'
-import { isPosition } from '../utils'
+import { isPosition, degreesToRadians } from '../utils'
 import type { Calculation, CalculationFactory } from '../types'
 
 const factory: CalculationFactory = function (app, plugin): Calculation {
@@ -64,18 +64,20 @@ const factory: CalculationFactory = function (app, plugin): Calculation {
         const targetDate = new Date(date)
         targetDate.setDate(targetDate.getDate() + day)
 
-        const illumination = suncalc.getMoonIllumination(
-          targetDate
-        ) as unknown as Record<string, number>
-        Object.keys(illumination).forEach((key) => {
-          illumination[key] = Math.round(illumination[key]! * 100) / 100
-        })
+        const illumination = suncalc.getMoonIllumination(targetDate)
+        // suncalc v2 returns the bright-limb angle in degrees; SignalK
+        // expects angles in radians, so convert it. fraction and phase are
+        // unitless ratios and pass through unchanged.
+        const fraction = Math.round(illumination.fraction * 100) / 100
+        const phase = Math.round(illumination.phase * 100) / 100
+        const angle =
+          Math.round(degreesToRadians(illumination.angle) * 100) / 100
         app.debug(
-          `moon illumination day ${day}:` +
-            JSON.stringify(illumination, null, 2)
+          `moon illumination day ${day}: ` +
+            JSON.stringify({ fraction, phase, angle }, null, 2)
         )
 
-        const phaseName = getPhaseName(illumination['phase']!)
+        const phaseName = getPhaseName(phase)
         app.debug(`Phase Name day ${day}: ${phaseName}`)
 
         const times = suncalc.getMoonTimes(
@@ -89,20 +91,14 @@ const factory: CalculationFactory = function (app, plugin): Calculation {
           day === 0 ? 'environment.moon' : `environment.moon.${day}`
 
         results.push(
-          { path: `${prefix}.fraction`, value: illumination['fraction'] },
-          { path: `${prefix}.phase`, value: illumination['phase'] },
+          { path: `${prefix}.fraction`, value: fraction },
+          { path: `${prefix}.phase`, value: phase },
           { path: `${prefix}.phaseName`, value: phaseName },
-          { path: `${prefix}.angle`, value: illumination['angle'] },
+          { path: `${prefix}.angle`, value: angle },
           { path: `${prefix}.times.rise`, value: times.rise || null },
           { path: `${prefix}.times.set`, value: times.set || null },
-          {
-            path: `${prefix}.times.alwaysUp`,
-            value: !!(times as { alwaysUp?: boolean }).alwaysUp
-          },
-          {
-            path: `${prefix}.times.alwaysDown`,
-            value: !!(times as { alwaysDown?: boolean }).alwaysDown
-          }
+          { path: `${prefix}.times.alwaysUp`, value: !!times.alwaysUp },
+          { path: `${prefix}.times.alwaysDown`, value: !!times.alwaysDown }
         )
       }
 

--- a/src/calcs/suncalc.ts
+++ b/src/calcs/suncalc.ts
@@ -90,9 +90,9 @@ const factory: CalculationFactory = function (app, _plugin): Calculation {
         input: ['2024-06-21T12:00:00Z', { latitude: null, longitude: null }]
       },
       // Day-side branches. All datetimes are on 2024-06-21 at lat/lon 0,0,
-      // which gives this fixed schedule (UTC):
-      //   nauticalDawn 05:10 | dawn 05:37 | sunrise 05:59 | sunriseEnd 06:02
-      //   sunsetStart 18:04 | sunset 18:07 | dusk 18:29 | nauticalDusk 18:55 | night 19:22
+      // which gives this fixed schedule (UTC, suncalc v2):
+      //   nauticalDawn 05:09 | dawn 05:35 | sunrise 05:58 | sunriseEnd 06:00
+      //   sunsetStart 18:03 | sunset 18:05 | dusk 18:28 | nauticalDusk 18:54 | night 19:20
       {
         input: ['2024-06-21T06:00:00Z', { latitude: 0, longitude: 0 }],
         expected: [

--- a/test/moon.ts
+++ b/test/moon.ts
@@ -21,10 +21,12 @@ describe('moon (covers the calculator path with valid inputs)', () => {
     const byPath: Record<string, any> = Object.fromEntries(
       out.map((x: any) => [x.path, x.value])
     )
-    byPath['environment.moon.fraction'].should.be.closeTo(0.73, 1e-9)
+    byPath['environment.moon.fraction'].should.be.closeTo(0.74, 1e-9)
     byPath['environment.moon.phase'].should.be.closeTo(0.67, 1e-9)
     byPath['environment.moon.phaseName'].should.equal('Waning Gibbous')
-    byPath['environment.moon.angle'].should.be.closeTo(1.94, 1e-9)
+    // suncalc v2 reports the bright-limb angle in degrees (110.84°); the
+    // calculator converts it to radians and rounds to 1.93.
+    byPath['environment.moon.angle'].should.be.closeTo(1.93, 1e-9)
     byPath['environment.moon.times.rise'].should.be.an.instanceof(Date)
     byPath['environment.moon.times.set'].should.be.an.instanceof(Date)
     byPath['environment.moon.times.alwaysUp'].should.equal(false)

--- a/test/suntime.ts
+++ b/test/suntime.ts
@@ -23,22 +23,22 @@ describe('suntime', () => {
       ])
     )
     byPath['environment.sunlight.times.sunrise'].should.equal(
-      '2024-06-21T05:59:28.185Z'
+      '2024-06-21T05:58:14.441Z'
     )
     byPath['environment.sunlight.times.solarNoon'].should.equal(
-      '2024-06-21T12:03:06.088Z'
+      '2024-06-21T12:01:55.638Z'
     )
     byPath['environment.sunlight.times.sunset'].should.equal(
-      '2024-06-21T18:06:43.990Z'
+      '2024-06-21T18:05:36.827Z'
     )
     byPath['environment.sunlight.times.nauticalDawn'].should.equal(
-      '2024-06-21T05:10:42.648Z'
+      '2024-06-21T05:09:28.494Z'
     )
     byPath['environment.sunlight.times.dawn'].should.equal(
-      '2024-06-21T05:36:56.029Z'
+      '2024-06-21T05:35:42.096Z'
     )
     byPath['environment.sunlight.times.night'].should.equal(
-      '2024-06-21T19:21:49.929Z'
+      '2024-06-21T19:20:43.293Z'
     )
   })
 


### PR DESCRIPTION
Adapts the plugin to suncalc 2.0.0 and includes the dependency bump. This supersedes the dependabot bump in #281, which only changed the version: suncalc v2 is a precision-focused rewrite with breaking API changes that require code adaptation.

## Breaking changes handled

- **Moon angle unit.** suncalc v2 returns the moon bright-limb angle in degrees instead of radians. Since SignalK uses SI units (and v1 emitted radians), the moon calculator now converts the angle back to radians so `environment.moon.angle` stays backward-compatible.
- **`waxing` flag.** v2 adds a boolean `waxing` field to `getMoonIllumination`. The previous code rounded every returned key generically, which would coerce the new boolean into a number; the calculator now reads the typed `fraction`/`phase`/`angle` fields explicitly.
- **Improved accuracy.** The rewrite shifts sun/moon times by up to ~1 minute. Pinned test expectations (suntime, moon) and the schedule comment in the sun calculator are updated to the v2 values.
- **Bundled types.** Dropped `@types/suncalc`; v2 ships its own type declarations.

The ESM-first / UTC-instant / `null`-for-missing-event changes need no code changes: `require` resolves the bundled CJS build, and missing-event handling was already in place.

## Verification

- `tsc --noEmit`: clean
- `npm run build`: clean
- Test suite: 316 passing
- prettier: clean

Closes #281